### PR TITLE
Feature/logrus integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,6 @@ SERVER_PORT=8080
 
 # DigitalOcean
 DIGITALOCEAN_TOKEN=your_digitalocean_token_here
+
+#Logrus
+LOG_LEVEL=info

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"strconv"
 
-	fiberlog "github.com/gofiber/fiber/v2/log"
+	log "github.com/celestiaorg/talis/internal/logger"
 
 	"github.com/gofiber/fiber/v2"
 
@@ -21,18 +21,21 @@ import (
 )
 
 func main() {
+	// Configure logger
+	log.InitializeAndConfigure()
+
+	// Log that the application is starting
+	log.Info("Starting application...")
+
 	// Load .env file
 	if err := godotenv.Load(); err != nil {
-		fiberlog.Fatal("Error loading .env file")
+		log.Fatal("Error loading .env file")
 	}
-
-	// Configure logger
-	fiberlog.SetLevel(fiberlog.LevelInfo)
 
 	// This is temporary, we will pass them through the CLI later
 	dbPort, err := strconv.Atoi(os.Getenv("DB_PORT"))
 	if err != nil {
-		fiberlog.Fatalf("Failed to convert DB_PORT to int: %v", err)
+		log.Fatalf("Failed to convert DB_PORT to int: %v", err)
 	}
 
 	// Initialize database
@@ -45,7 +48,7 @@ func main() {
 		// SSLEnabled: os.Getenv("DB_SSL_MODE") == "true",
 	})
 	if err != nil {
-		fiberlog.Fatalf("Failed to connect to database: %v", err)
+		log.Fatalf("Failed to connect to database: %v", err)
 	}
 	// We will use connection pooling later
 	// defer DB.Close()
@@ -91,8 +94,8 @@ func main() {
 	})
 
 	// Start server
-	fiberlog.Info("Server starting on :8080")
-	fiberlog.Fatal(app.Listen(":8080"))
+	log.Info("Server starting on :8080")
+	log.Fatal(app.Listen(":8080"))
 }
 
 // customErrorHandler is a custom error handler for the Fiber app

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gofiber/fiber/v2 v2.52.6
 	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v1.10.9
+	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	gorm.io/driver/postgres v1.5.11
@@ -38,7 +39,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
-	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/f
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
@@ -88,6 +90,7 @@ golang.org/x/oauth2 v0.25.0 h1:CY4y7XT9v0cRI9oupztF8AgiIu99L/ksR/Xp/6jrZ70=
 golang.org/x/oauth2 v0.25.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
 golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=

--- a/internal/api/v1/handlers/job.go
+++ b/internal/api/v1/handlers/job.go
@@ -3,9 +3,10 @@ package handlers
 import (
 	"context"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
+
+	log "github.com/celestiaorg/talis/internal/logger"
 
 	"github.com/gofiber/fiber/v2"
 
@@ -145,7 +146,7 @@ func (h *JobHandler) CreateJob(c *fiber.Ctx) error {
 		if err != nil {
 			fmt.Printf("❌ Failed to create infrastructure: %v\n", err)
 			if err := h.service.UpdateJobStatus(context.Background(), job.ID, models.JobStatusFailed, nil, err.Error()); err != nil {
-				log.Printf("Failed to update job status: %v", err)
+				log.Infof("Failed to update job status: %v", err)
 			}
 			return
 		}
@@ -165,7 +166,7 @@ func (h *JobHandler) CreateJob(c *fiber.Ctx) error {
 			} else {
 				fmt.Printf("❌ Failed to execute infrastructure: %v\n", err)
 				if err := h.service.UpdateJobStatus(context.Background(), job.ID, models.JobStatusFailed, nil, err.Error()); err != nil {
-					log.Printf("Failed to update job status: %v", err)
+					log.Infof("Failed to update job status: %v", err)
 				}
 				return
 			}
@@ -178,7 +179,7 @@ func (h *JobHandler) CreateJob(c *fiber.Ctx) error {
 				fmt.Printf("❌ Invalid result type: %T\n", result)
 				if err := h.service.UpdateJobStatus(context.Background(), job.ID, models.JobStatusFailed, nil,
 					fmt.Sprintf("invalid result type: %T, expected []infrastructure.InstanceInfo", result)); err != nil {
-					log.Printf("Failed to update job status: %v", err)
+					log.Infof("Failed to update job status: %v", err)
 				}
 				return
 			}
@@ -194,7 +195,7 @@ func (h *JobHandler) CreateJob(c *fiber.Ctx) error {
 			if err := infra.RunProvisioning(instances); err != nil {
 				fmt.Printf("❌ Failed to run provisioning: %v\n", err)
 				if err := h.service.UpdateJobStatus(context.Background(), job.ID, models.JobStatusFailed, instances, fmt.Sprintf("infrastructure created but provisioning failed: %v", err)); err != nil {
-					log.Printf("Failed to update job status: %v", err)
+					log.Infof("Failed to update job status: %v", err)
 				}
 				return
 			}

--- a/internal/api/v1/middleware/logger.go
+++ b/internal/api/v1/middleware/logger.go
@@ -3,8 +3,8 @@ package middleware
 import (
 	"time"
 
+	log "github.com/celestiaorg/talis/internal/logger"
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/log"
 )
 
 // Logger returns a middleware that logs HTTP requests
@@ -20,15 +20,15 @@ func Logger() fiber.Handler {
 		latency := stop.Sub(start)
 
 		// Log using Fiber's logger
-		log.Infow("Request",
-			"timestamp", stop.Format("2006/01/02 - 15:04:05"),
-			"status", c.Response().StatusCode(),
-			"latency", latency,
-			"ip", c.IP(),
-			"method", c.Method(),
-			"path", c.Path(),
-			"handler", c.Route().Name,
-		)
+		log.InfoWithFields("Request", map[string]interface{}{
+			"timestamp": stop.Format("2006/01/02 - 15:04:05"),
+			"status":    c.Response().StatusCode(),
+			"latency":   latency,
+			"ip":        c.IP(),
+			"method":    c.Method(),
+			"path":      c.Path(),
+			"handler":   c.Route().Name,
+		})
 
 		return err
 	}

--- a/internal/logger/level.go
+++ b/internal/logger/level.go
@@ -1,0 +1,1 @@
+package logger

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -7,79 +7,81 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var talisLog = logrus.New()
+var log = logrus.New()
 
 // Initialize sets up the logger with the appropriate configuration
 // and log level from environment variables
-func Initialize() {
-	var log = logrus.New()
+func InitializeAndConfigure() {
 
+	// Set default formatter
 	log.SetFormatter(&logrus.JSONFormatter{})
+
+	// Set output to stdout
+	log.SetOutput(os.Stdout)
+
+	// Try to read log level from environment
 	configureLogLevel()
 
 }
 
 func configureLogLevel() {
-	talisLog.SetLevel(logrus.InfoLevel)
+	log.SetLevel(logrus.InfoLevel)
 
 	levelStr := os.Getenv("LOG_LEVEL")
 	if levelStr == "" {
-		talisLog.Warnf("Invalid log level '%s', defaulting to 'info'", levelStr)
+		log.Warnf("Invalid log level '%s', defaulting to 'info'", levelStr)
+		// Defaults to InfoLevel set above
 		return
 	}
 
+	// Parse the log level string
 	level, err := logrus.ParseLevel(strings.ToLower(levelStr))
 	if err != nil {
 		// If parsing fails, log a warning and keep the default
-		talisLog.Warnf("Invalid log level '%s', defaulting to 'info'", levelStr)
+		log.Warnf("Invalid log level '%s', defaulting to 'info'", levelStr)
 		return
 	}
 
-	talisLog.SetLevel(level)
-	talisLog.Infof("Log level set to '%s'", level)
+	log.SetLevel(level)
+	log.Infof("Log level set to '%s'", level)
 
-}
-
-// GetLogger returns the configured logger instance
-func GetLogger() *logrus.Logger {
-	return talisLog
 }
 
 //Logrus has seven logging levels: Trace, Debug, Info, Warning, Error, Fatal and Panic.
 
 // Trace logs a message at the Trace level
 func Trace(args ...interface{}) {
-	talisLog.Trace(args...)
+	log.Trace(args...)
 }
 
 // Debug logs a message at the debug level
 func Debug(args ...interface{}) {
-	talisLog.Debug(args...)
+	log.Debug(args...)
 }
 
 // Info logs a message at the Info level
 func Info(args ...interface{}) {
-	talisLog.Info(args...)
+	log.Info(args...)
 }
 
 // Warn logs a message at the Warn level
 func Warn(args ...interface{}) {
-	talisLog.Warn(args...)
+	log.Warn(args...)
 }
 
 // Error logs a message at the Error level
 func Error(args ...interface{}) {
-	talisLog.Error(args...)
+	log.Error(args...)
 }
 
 // Fatal logs a message at the Fatal level
 func Fatal(args ...interface{}) {
-	talisLog.Fatal(args...)
+	log.Fatal(args...)
 }
 
 // Panic logs a message at the Panic level
 func Panic(args ...interface{}) {
-	talisLog.Panic(args...)
+	log.Panic(args...)
 }
 
 // Formatted Logs
@@ -87,35 +89,72 @@ func Panic(args ...interface{}) {
 
 // Tracef logs a message at the TraceF level
 func Tracef(format string, args ...interface{}) {
-	talisLog.Tracef(format, args...)
+	log.Tracef(format, args...)
 }
 
 // Debugf logs a message at the Debugf level
 func Debugf(format string, args ...interface{}) {
-	talisLog.Debugf(format, args...)
+	log.Debugf(format, args...)
 }
 
 // Infof logs a message at the Infof level
 func Infof(format string, args ...interface{}) {
-	talisLog.Infof(format, args...)
+	log.Infof(format, args...)
 }
 
 // Warnf logs a message at the Warnf level
 func Warnf(format string, args ...interface{}) {
-	talisLog.Warnf(format, args...)
+	log.Warnf(format, args...)
 }
 
 // Errorf logs a message at the Errorf level
 func Errorf(format string, args ...interface{}) {
-	talisLog.Errorf(format, args...)
+	log.Errorf(format, args...)
 }
 
 // Fatalf logs a message at the Fatalf level
 func Fatalf(format string, args ...interface{}) {
-	talisLog.Fatalf(format, args...)
+	log.Fatalf(format, args...)
 }
 
 // Panicf logs a message at the Panicf level
 func Panicf(format string, args ...interface{}) {
-	talisLog.Panicf(format, args...)
+	log.Panicf(format, args...)
+}
+
+// Log levels with fields
+
+// InfoWithFields logs a message at the info level with additional fields
+func InfoWithFields(msg string, fields map[string]interface{}) {
+	log.WithFields(logrus.Fields(fields)).Info(msg)
+}
+
+// DebugWithFields logs a message at the debug level with additional fields
+func DebugWithFields(msg string, fields map[string]interface{}) {
+	log.WithFields(logrus.Fields(fields)).Debug(msg)
+}
+
+// WarnWithFields logs a message at the warn level with additional fields
+func WarnWithFields(msg string, fields map[string]interface{}) {
+	log.WithFields(logrus.Fields(fields)).Warn(msg)
+}
+
+// ErrorWithFields logs a message at the error level with additional fields
+func ErrorWithFields(msg string, fields map[string]interface{}) {
+	log.WithFields(logrus.Fields(fields)).Error(msg)
+}
+
+// FatalWithFields logs a message at the fatal level with additional fields
+func FatalWithFields(msg string, fields map[string]interface{}) {
+	log.WithFields(logrus.Fields(fields)).Fatal(msg)
+}
+
+// PanicWithFields logs a message at the panic level with additional fields
+func PanicWithFields(msg string, fields map[string]interface{}) {
+	log.WithFields(logrus.Fields(fields)).Panic(msg)
+}
+
+// TraceWithFields logs a message at the trace level with additional fields
+func TraceWithFields(msg string, fields map[string]interface{}) {
+	log.WithFields(logrus.Fields(fields)).Trace(msg)
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -9,6 +9,8 @@ import (
 
 var talisLog = logrus.New()
 
+// Initialize sets up the logger with the appropriate configuration
+// and log level from environment variables
 func Initialize() {
 	var log = logrus.New()
 
@@ -36,4 +38,84 @@ func configureLogLevel() {
 	talisLog.SetLevel(level)
 	talisLog.Infof("Log level set to '%s'", level)
 
+}
+
+// GetLogger returns the configured logger instance
+func GetLogger() *logrus.Logger {
+	return talisLog
+}
+
+//Logrus has seven logging levels: Trace, Debug, Info, Warning, Error, Fatal and Panic.
+
+// Trace logs a message at the Trace level
+func Trace(args ...interface{}) {
+	talisLog.Trace(args...)
+}
+
+// Debug logs a message at the debug level
+func Debug(args ...interface{}) {
+	talisLog.Debug(args...)
+}
+
+// Info logs a message at the Info level
+func Info(args ...interface{}) {
+	talisLog.Info(args...)
+}
+
+// Warn logs a message at the Warn level
+func Warn(args ...interface{}) {
+	talisLog.Warn(args...)
+}
+
+// Error logs a message at the Error level
+func Error(args ...interface{}) {
+	talisLog.Error(args...)
+}
+
+// Fatal logs a message at the Fatal level
+func Fatal(args ...interface{}) {
+	talisLog.Fatal(args...)
+}
+
+// Panic logs a message at the Panic level
+func Panic(args ...interface{}) {
+	talisLog.Panic(args...)
+}
+
+// Formatted Logs
+//
+
+// Tracef logs a message at the TraceF level
+func Tracef(format string, args ...interface{}) {
+	talisLog.Tracef(format, args...)
+}
+
+// Debugf logs a message at the Debugf level
+func Debugf(format string, args ...interface{}) {
+	talisLog.Debugf(format, args...)
+}
+
+// Infof logs a message at the Infof level
+func Infof(format string, args ...interface{}) {
+	talisLog.Infof(format, args...)
+}
+
+// Warnf logs a message at the Warnf level
+func Warnf(format string, args ...interface{}) {
+	talisLog.Warnf(format, args...)
+}
+
+// Errorf logs a message at the Errorf level
+func Errorf(format string, args ...interface{}) {
+	talisLog.Errorf(format, args...)
+}
+
+// Fatalf logs a message at the Fatalf level
+func Fatalf(format string, args ...interface{}) {
+	talisLog.Fatalf(format, args...)
+}
+
+// Panicf logs a message at the Panicf level
+func Panicf(format string, args ...interface{}) {
+	talisLog.Panicf(format, args...)
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,39 @@
+package logger
+
+import (
+	"os"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+var talisLog = logrus.New()
+
+func Initialize() {
+	var log = logrus.New()
+
+	log.SetFormatter(&logrus.JSONFormatter{})
+	configureLogLevel()
+
+}
+
+func configureLogLevel() {
+	talisLog.SetLevel(logrus.InfoLevel)
+
+	levelStr := os.Getenv("LOG_LEVEL")
+	if levelStr == "" {
+		talisLog.Warnf("Invalid log level '%s', defaulting to 'info'", levelStr)
+		return
+	}
+
+	level, err := logrus.ParseLevel(strings.ToLower(levelStr))
+	if err != nil {
+		// If parsing fails, log a warning and keep the default
+		talisLog.Warnf("Invalid log level '%s', defaulting to 'info'", levelStr)
+		return
+	}
+
+	talisLog.SetLevel(level)
+	talisLog.Infof("Log level set to '%s'", level)
+
+}


### PR DESCRIPTION
# Implement logrus for enhanced logging capabilities

## Background
This PR replaces the standard library logging with logrus to provide more robust logging capabilities throughout the Talis project. Currently, the project uses two different logging approaches: the standard library `log` package in most places and Fiber's built-in logger in the API middleware.

## Changes
- Created a centralized logging package in `internal/logger` that implements logrus
- Added configurable log levels with "info" as the default
- Implemented environment variable support via `LOG_LEVEL` to adjust logging verbosity
- Updated `.env.example` with the new `LOG_LEVEL` configuration option
- Modified the Fiber middleware to use logrus instead of its built-in logger
- Updated all existing log statements to use the new logger with appropriate log levels

## Rationale
Enhanced logging with different log levels will significantly improve debugging capabilities. By centralizing our logging implementation, we gain:
1. Consistent log formatting across the entire application
2. The ability to adjust verbosity through environment variables
3. Structured logging with fields for better searchability
4. More granular control over what gets logged

## Observation
There appears to be a redundant logger `internal/api/middleware/logger`. I can remove it when it's confirmed redundant

## Related Issue
Resolves [[#107](https://github.com/celestiaorg/talis/issues/107)](https://github.com/celestiaorg/talis/issues/107)