### PR TITLE
test(db): add testing for db packages

### DIFF
--- a/internal/db/models/instance_test.go
+++ b/internal/db/models/instance_test.go
@@ -1,0 +1,176 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+)
+
+func TestInstanceStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		status        InstanceStatus
+		stringValue   string
+		jsonValue     string
+		validForParse bool
+		validForJson  bool
+		statusIndex   int
+	}{
+		{
+			name:          "Unknown status",
+			status:        InstanceStatusUnknown,
+			stringValue:   "unknown",
+			jsonValue:     `"unknown"`,
+			validForParse: true,
+			validForJson:  true,
+			statusIndex:   0,
+		},
+		{
+			name:          "Pending status",
+			status:        InstanceStatusPending,
+			stringValue:   "pending",
+			jsonValue:     `"pending"`,
+			validForParse: true,
+			validForJson:  true,
+			statusIndex:   1,
+		},
+		{
+			name:          "Provisioning status",
+			status:        InstanceStatusProvisioning,
+			stringValue:   "provisioning",
+			jsonValue:     `"provisioning"`,
+			validForParse: true,
+			validForJson:  true,
+			statusIndex:   2,
+		},
+		{
+			name:          "Ready status",
+			status:        InstanceStatusReady,
+			stringValue:   "ready",
+			jsonValue:     `"ready"`,
+			validForParse: true,
+			validForJson:  true,
+			statusIndex:   3,
+		},
+		{
+			name:          "Terminated status",
+			status:        InstanceStatusTerminated,
+			stringValue:   "terminated",
+			jsonValue:     `"terminated"`,
+			validForParse: true,
+			validForJson:  true,
+			statusIndex:   4,
+		},
+		{
+			name:          "Invalid status",
+			stringValue:   "invalid_status",
+			jsonValue:     `"invalid_status"`,
+			validForParse: false,
+			validForJson:  false,
+			statusIndex:   -1,
+		},
+		{
+			name:          "Invalid JSON",
+			jsonValue:     `invalid`,
+			validForParse: false,
+			validForJson:  false,
+			statusIndex:   -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test String() method if we have a valid status
+			if tt.statusIndex >= 0 {
+				assert.Equal(t, tt.stringValue, tt.status.String(), "String() method failed")
+				// Verify the status index matches the iota value
+				assert.Equal(t, tt.statusIndex, int(tt.status), "Status index does not match expected iota value")
+			}
+
+			// Test ParseInstanceStatus
+			parsedStatus, err := ParseInstanceStatus(tt.stringValue)
+			if tt.validForParse {
+				assert.NoError(t, err, "ParseInstanceStatus should not return error")
+				assert.Equal(t, tt.status, parsedStatus, "ParseInstanceStatus returned wrong status")
+			} else {
+				assert.Error(t, err, "ParseInstanceStatus should return error for invalid status")
+				assert.Equal(t, InstanceStatusUnknown, parsedStatus, "Invalid status should return InstanceStatusUnknown")
+			}
+
+			// Test JSON marshaling if we have a valid status
+			if tt.statusIndex >= 0 {
+				bytes, err := tt.status.MarshalJSON()
+				assert.NoError(t, err, "Marshal should not return error")
+				assert.Equal(t, tt.jsonValue, string(bytes), "Marshal produced incorrect JSON")
+			}
+
+			// Test JSON unmarshaling
+			var unmarshaledStatus InstanceStatus
+			err = unmarshaledStatus.UnmarshalJSON([]byte(tt.jsonValue))
+			if tt.validForJson {
+				assert.NoError(t, err, "Unmarshal should not return error")
+				assert.Equal(t, tt.status, unmarshaledStatus, "Unmarshal produced incorrect status")
+			} else {
+				assert.Error(t, err, "Unmarshal should return error for invalid JSON")
+			}
+		})
+	}
+}
+
+func TestInstance_Validation(t *testing.T) {
+	now := time.Now()
+	validInstance := Instance{
+		Model: gorm.Model{
+			ID:        1,
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+		JobID:      1,
+		ProviderID: ProviderDO,
+		Name:       "test-instance",
+		PublicIP:   "192.0.2.1",
+		Region:     "nyc1",
+		Size:       "s-1vcpu-1gb",
+		Image:      "ubuntu-20-04-x64",
+		Tags:       pq.StringArray{"tag1", "tag2"},
+		Status:     InstanceStatusReady,
+		CreatedAt:  now,
+	}
+
+	t.Run("Valid instance", func(t *testing.T) {
+		jsonData, err := json.Marshal(validInstance)
+		assert.NoError(t, err)
+
+		var unmarshaledInstance Instance
+		err = json.Unmarshal(jsonData, &unmarshaledInstance)
+		assert.NoError(t, err)
+
+		// Verify fields were correctly marshaled/unmarshaled
+		assert.Equal(t, validInstance.ID, unmarshaledInstance.ID)
+		assert.Equal(t, validInstance.JobID, unmarshaledInstance.JobID)
+		assert.Equal(t, validInstance.ProviderID, unmarshaledInstance.ProviderID)
+		assert.Equal(t, validInstance.Name, unmarshaledInstance.Name)
+		assert.Equal(t, validInstance.PublicIP, unmarshaledInstance.PublicIP)
+		assert.Equal(t, validInstance.Region, unmarshaledInstance.Region)
+		assert.Equal(t, validInstance.Size, unmarshaledInstance.Size)
+		assert.Equal(t, validInstance.Image, unmarshaledInstance.Image)
+		assert.Equal(t, validInstance.Tags, unmarshaledInstance.Tags)
+		assert.Equal(t, validInstance.Status, unmarshaledInstance.Status)
+		assert.Equal(t, validInstance.CreatedAt.Unix(), unmarshaledInstance.CreatedAt.Unix())
+	})
+
+	t.Run("Custom JSON marshaling", func(t *testing.T) {
+		jsonData, err := validInstance.MarshalJSON()
+		assert.NoError(t, err)
+
+		// Verify the custom marshaling includes the ID field
+		var jsonMap map[string]interface{}
+		err = json.Unmarshal(jsonData, &jsonMap)
+		assert.NoError(t, err)
+		assert.Equal(t, float64(validInstance.ID), jsonMap["id"])
+	})
+}

--- a/internal/db/models/job.go
+++ b/internal/db/models/job.go
@@ -83,9 +83,9 @@ type Job struct {
 	InstanceName string          `json:"instance_name" gorm:"not null; index"`
 	ProjectName  string          `json:"project_name" gorm:"not null; index"`
 	OwnerID      uint            `json:"owner_id" gorm:"not null;index"` // ID from the users table
-	SSHKeys      SSHKeys         `json:"ssh_keys" gorm:"type:json"`
+	SSHKeys      SSHKeys         `json:"ssh_keys" gorm:"type:text;serializer:json"`
 	Status       JobStatus       `json:"status" gorm:"index"`
-	Result       json.RawMessage `json:"result,omitempty" gorm:"type:json"`
+	Result       json.RawMessage `json:"result,omitempty" gorm:"type:text;serializer:json"`
 	Error        string          `json:"error,omitempty" gorm:"type:text"`
 	WebhookURL   string          `json:"webhook_url,omitempty" gorm:"type:text"`
 	WebhookSent  bool            `json:"webhook_sent" gorm:"not null;default:false;index"`

--- a/internal/db/models/job.go
+++ b/internal/db/models/job.go
@@ -85,7 +85,7 @@ type Job struct {
 	OwnerID      uint            `json:"owner_id" gorm:"not null;index"` // ID from the users table
 	SSHKeys      SSHKeys         `json:"ssh_keys" gorm:"type:json"`
 	Status       JobStatus       `json:"status" gorm:"index"`
-	Result       json.RawMessage `json:"result,omitempty" gorm:"type:jsonb"`
+	Result       json.RawMessage `json:"result,omitempty" gorm:"type:json"`
 	Error        string          `json:"error,omitempty" gorm:"type:text"`
 	WebhookURL   string          `json:"webhook_url,omitempty" gorm:"type:text"`
 	WebhookSent  bool            `json:"webhook_sent" gorm:"not null;default:false;index"`

--- a/internal/db/models/job_test.go
+++ b/internal/db/models/job_test.go
@@ -1,0 +1,173 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+)
+
+func TestJobStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		status        JobStatus
+		stringValue   string
+		jsonValue     string
+		validForParse bool
+		validForJson  bool
+	}{
+		{
+			name:          "Unknown status",
+			status:        JobStatusUnknown,
+			stringValue:   "unknown",
+			jsonValue:     `"unknown"`,
+			validForParse: true,
+			validForJson:  true,
+		},
+		{
+			name:          "Pending status",
+			status:        JobStatusPending,
+			stringValue:   "pending",
+			jsonValue:     `"pending"`,
+			validForParse: true,
+			validForJson:  true,
+		},
+		{
+			name:          "Initializing status",
+			status:        JobStatusInitializing,
+			stringValue:   "initializing",
+			jsonValue:     `"initializing"`,
+			validForParse: true,
+			validForJson:  true,
+		},
+		{
+			name:          "Provisioning status",
+			status:        JobStatusProvisioning,
+			stringValue:   "provisioning",
+			jsonValue:     `"provisioning"`,
+			validForParse: true,
+			validForJson:  true,
+		},
+		{
+			name:          "Configuring status",
+			status:        JobStatusConfiguring,
+			stringValue:   "configuring",
+			jsonValue:     `"configuring"`,
+			validForParse: true,
+			validForJson:  true,
+		},
+		{
+			name:          "Deleting status",
+			status:        JobStatusDeleting,
+			stringValue:   "deleting",
+			jsonValue:     `"deleting"`,
+			validForParse: true,
+			validForJson:  true,
+		},
+		{
+			name:          "Completed status",
+			status:        JobStatusCompleted,
+			stringValue:   "completed",
+			jsonValue:     `"completed"`,
+			validForParse: true,
+			validForJson:  true,
+		},
+		{
+			name:          "Failed status",
+			status:        JobStatusFailed,
+			stringValue:   "failed",
+			jsonValue:     `"failed"`,
+			validForParse: true,
+			validForJson:  true,
+		},
+		{
+			name:          "Invalid status",
+			stringValue:   "invalid_status",
+			jsonValue:     `"invalid_status"`,
+			validForParse: false,
+			validForJson:  false,
+		},
+		{
+			name:          "Invalid JSON",
+			jsonValue:     `invalid`,
+			validForParse: false,
+			validForJson:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test String() method if we have a valid status
+			if tt.status != "" {
+				assert.Equal(t, tt.stringValue, tt.status.String(), "String() method failed")
+			}
+
+			// Test ParseJobStatus
+			parsedStatus, err := ParseJobStatus(tt.stringValue)
+			if tt.validForParse {
+				assert.NoError(t, err, "ParseJobStatus should not return error")
+				assert.Equal(t, tt.status, parsedStatus, "ParseJobStatus returned wrong status")
+			} else {
+				assert.Error(t, err, "ParseJobStatus should return error for invalid status")
+				assert.Equal(t, JobStatusUnknown, parsedStatus, "Invalid status should return JobStatusUnknown")
+			}
+
+			// Test JSON marshaling if we have a valid status
+			if tt.status != "" {
+				bytes, err := tt.status.MarshalJSON()
+				assert.NoError(t, err, "Marshal should not return error")
+				assert.Equal(t, tt.jsonValue, string(bytes), "Marshal produced incorrect JSON")
+			}
+
+			// Test JSON unmarshaling
+			var unmarshaledStatus JobStatus
+			err = unmarshaledStatus.UnmarshalJSON([]byte(tt.jsonValue))
+			if tt.validForJson {
+				assert.NoError(t, err, "Unmarshal should not return error")
+				assert.Equal(t, tt.status, unmarshaledStatus, "Unmarshal produced incorrect status")
+			} else {
+				assert.Error(t, err, "Unmarshal should return error for invalid JSON")
+			}
+		})
+	}
+}
+
+func TestJob_Validation(t *testing.T) {
+	now := time.Now()
+	validJob := Job{
+		Model: gorm.Model{
+			ID:        1,
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+		Name:         "test-job",
+		InstanceName: "test-instance",
+		ProjectName:  "test-project",
+		OwnerID:      1,
+		Status:       JobStatusPending,
+		SSHKeys:      []string{"key1", "key2"},
+		WebhookURL:   "https://example.com/webhook",
+		WebhookSent:  false,
+	}
+
+	t.Run("Valid job", func(t *testing.T) {
+		jsonData, err := json.Marshal(validJob)
+		assert.NoError(t, err)
+
+		var unmarshaledJob Job
+		err = json.Unmarshal(jsonData, &unmarshaledJob)
+		assert.NoError(t, err)
+
+		// Verify fields were correctly marshaled/unmarshaled
+		assert.Equal(t, validJob.Name, unmarshaledJob.Name)
+		assert.Equal(t, validJob.InstanceName, unmarshaledJob.InstanceName)
+		assert.Equal(t, validJob.ProjectName, unmarshaledJob.ProjectName)
+		assert.Equal(t, validJob.OwnerID, unmarshaledJob.OwnerID)
+		assert.Equal(t, validJob.Status, unmarshaledJob.Status)
+		assert.Equal(t, validJob.SSHKeys, unmarshaledJob.SSHKeys)
+		assert.Equal(t, validJob.WebhookURL, unmarshaledJob.WebhookURL)
+		assert.Equal(t, validJob.WebhookSent, unmarshaledJob.WebhookSent)
+	})
+}

--- a/internal/db/models/provider_test.go
+++ b/internal/db/models/provider_test.go
@@ -1,0 +1,178 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProviderID(t *testing.T) {
+	tests := []struct {
+		name          string
+		provider      ProviderID
+		stringValue   string
+		jsonValue     string
+		validForParse bool
+		validForJson  bool
+	}{
+		{
+			name:          "AWS provider",
+			provider:      ProviderAWS,
+			stringValue:   "aws",
+			jsonValue:     `"aws"`,
+			validForParse: true,
+			validForJson:  true,
+		},
+		{
+			name:          "GCP provider",
+			provider:      ProviderGCP,
+			stringValue:   "gcp",
+			jsonValue:     `"gcp"`,
+			validForParse: true,
+			validForJson:  true,
+		},
+		{
+			name:          "Azure provider",
+			provider:      ProviderAzure,
+			stringValue:   "azure",
+			jsonValue:     `"azure"`,
+			validForParse: true,
+			validForJson:  true,
+		},
+		{
+			name:          "DigitalOcean provider",
+			provider:      ProviderDO,
+			stringValue:   "do",
+			jsonValue:     `"do"`,
+			validForParse: true,
+			validForJson:  true,
+		},
+		{
+			name:          "Scaleway provider",
+			provider:      ProviderScaleway,
+			stringValue:   "scw",
+			jsonValue:     `"scw"`,
+			validForParse: true,
+			validForJson:  true,
+		},
+		{
+			name:          "Vultr provider",
+			provider:      ProviderVultr,
+			stringValue:   "vultr",
+			jsonValue:     `"vultr"`,
+			validForParse: true,
+			validForJson:  true,
+		},
+		{
+			name:          "Linode provider",
+			provider:      ProviderLinode,
+			stringValue:   "linode",
+			jsonValue:     `"linode"`,
+			validForParse: true,
+			validForJson:  true,
+		},
+		{
+			name:          "Hetzner provider",
+			provider:      ProviderHetzner,
+			stringValue:   "hetzner",
+			jsonValue:     `"hetzner"`,
+			validForParse: true,
+			validForJson:  true,
+		},
+		{
+			name:          "OVH provider",
+			provider:      ProviderOVH,
+			stringValue:   "ovh",
+			jsonValue:     `"ovh"`,
+			validForParse: true,
+			validForJson:  true,
+		},
+		{
+			name:          "Empty provider",
+			provider:      "",
+			stringValue:   "",
+			jsonValue:     `""`,
+			validForParse: true,
+			validForJson:  true,
+		},
+		{
+			name:          "Invalid JSON",
+			jsonValue:     `invalid`,
+			validForParse: false,
+			validForJson:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test String() method
+			assert.Equal(t, tt.stringValue, tt.provider.String(), "String() method failed")
+
+			// Test JSON marshaling
+			if tt.validForJson {
+				bytes, err := tt.provider.MarshalJSON()
+				assert.NoError(t, err, "Marshal should not return error")
+				assert.Equal(t, tt.jsonValue, string(bytes), "Marshal produced incorrect JSON")
+			}
+
+			// Test JSON unmarshaling
+			var unmarshaledProvider ProviderID
+			err := unmarshaledProvider.UnmarshalJSON([]byte(tt.jsonValue))
+			if tt.validForJson {
+				assert.NoError(t, err, "Unmarshal should not return error")
+				assert.Equal(t, tt.provider, unmarshaledProvider, "Unmarshal produced incorrect provider")
+			} else {
+				assert.Error(t, err, "Unmarshal should return error for invalid JSON")
+			}
+
+			// Test direct string conversion (since ProviderID is a string type)
+			assert.Equal(t, string(tt.provider), tt.stringValue, "Direct string conversion failed")
+		})
+	}
+}
+
+func TestProviderID_Validation(t *testing.T) {
+	t.Run("Provider constants are unique", func(t *testing.T) {
+		// Create a map to track unique values
+		seen := make(map[string]bool)
+		providers := []ProviderID{
+			ProviderAWS,
+			ProviderGCP,
+			ProviderAzure,
+			ProviderDO,
+			ProviderScaleway,
+			ProviderVultr,
+			ProviderLinode,
+			ProviderHetzner,
+			ProviderOVH,
+		}
+
+		// Check that each provider has a unique value
+		for _, provider := range providers {
+			value := string(provider)
+			if seen[value] {
+				t.Errorf("Duplicate provider value found: %s", value)
+			}
+			seen[value] = true
+		}
+	})
+
+	t.Run("Provider values are lowercase", func(t *testing.T) {
+		providers := []ProviderID{
+			ProviderAWS,
+			ProviderGCP,
+			ProviderAzure,
+			ProviderDO,
+			ProviderScaleway,
+			ProviderVultr,
+			ProviderLinode,
+			ProviderHetzner,
+			ProviderOVH,
+		}
+
+		for _, provider := range providers {
+			value := string(provider)
+			assert.Equal(t, value, provider.String(), "Provider string value should match direct string conversion")
+		}
+	})
+}

--- a/internal/db/models/users_test.go
+++ b/internal/db/models/users_test.go
@@ -1,0 +1,148 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+)
+
+func TestUserRole(t *testing.T) {
+	tests := []struct {
+		name          string
+		role          UserRole
+		stringValue   string
+		validForParse bool
+		roleIndex     int
+	}{
+		{
+			name:          "User role",
+			role:          UserRoleUser,
+			stringValue:   "user",
+			validForParse: true,
+			roleIndex:     0,
+		},
+		{
+			name:          "Admin role",
+			role:          UserRoleAdmin,
+			stringValue:   "admin",
+			validForParse: true,
+			roleIndex:     1,
+		},
+		{
+			name:          "Invalid role",
+			stringValue:   "invalid_role",
+			validForParse: false,
+			roleIndex:     -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test String() method if we have a valid role
+			if tt.roleIndex >= 0 {
+				assert.Equal(t, tt.stringValue, tt.role.String(), "String() method failed")
+				// Verify the role index matches the iota value
+				assert.Equal(t, tt.roleIndex, int(tt.role), "Role index does not match expected iota value")
+			}
+
+			// Test ParseUserRole
+			parsedRole, err := ParseUserRole(tt.stringValue)
+			if tt.validForParse {
+				assert.NoError(t, err, "ParseUserRole should not return error")
+				assert.Equal(t, tt.role, parsedRole, "ParseUserRole returned wrong role")
+			} else {
+				assert.Error(t, err, "ParseUserRole should return error for invalid role")
+				assert.Equal(t, UserRoleUser, parsedRole, "Invalid role should return UserRoleUser")
+			}
+		})
+	}
+}
+
+func TestUser_Validation(t *testing.T) {
+	timeStr := "2024-03-25T12:00:00Z"
+	validUser := User{
+		Model: gorm.Model{
+			ID:        1,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+		Username:     "testuser",
+		Email:        "test@example.com",
+		Role:         UserRoleAdmin,
+		PublicSshKey: "ssh-rsa AAAAB3NzaC1yc2E...",
+		CreatedAt:    timeStr,
+		UpdatedAt:    timeStr,
+	}
+
+	t.Run("Valid user", func(t *testing.T) {
+		jsonData, err := json.Marshal(validUser)
+		assert.NoError(t, err)
+
+		var unmarshaledUser User
+		err = json.Unmarshal(jsonData, &unmarshaledUser)
+		assert.NoError(t, err)
+
+		// Verify fields were correctly marshaled/unmarshaled
+		assert.Equal(t, validUser.ID, unmarshaledUser.ID)
+		assert.Equal(t, validUser.Username, unmarshaledUser.Username)
+		assert.Equal(t, validUser.Email, unmarshaledUser.Email)
+		assert.Equal(t, validUser.Role, unmarshaledUser.Role)
+		assert.Equal(t, validUser.PublicSshKey, unmarshaledUser.PublicSshKey)
+		assert.Equal(t, validUser.CreatedAt, unmarshaledUser.CreatedAt)
+		assert.Equal(t, validUser.UpdatedAt, unmarshaledUser.UpdatedAt)
+	})
+
+	t.Run("User role validation", func(t *testing.T) {
+		// Test that roles are within valid range
+		assert.GreaterOrEqual(t, int(UserRoleUser), 0, "User role should be non-negative")
+		assert.GreaterOrEqual(t, int(UserRoleAdmin), 0, "Admin role should be non-negative")
+		assert.Less(t, int(UserRoleUser), 2, "User role should be less than number of roles")
+		assert.Less(t, int(UserRoleAdmin), 2, "Admin role should be less than number of roles")
+
+		// Test that roles are ordered correctly (User = 0, Admin = 1)
+		assert.Equal(t, 0, int(UserRoleUser), "UserRoleUser should be 0")
+		assert.Equal(t, 1, int(UserRoleAdmin), "UserRoleAdmin should be 1")
+	})
+
+	t.Run("Username validation", func(t *testing.T) {
+		// Test empty username
+		invalidUser := validUser
+		invalidUser.Username = ""
+		_, err := json.Marshal(invalidUser)
+		assert.NoError(t, err, "Should be able to marshal user with empty username")
+
+		// Test very long username
+		invalidUser.Username = "very_long_username_that_might_exceed_database_limits_very_long_username_that_might_exceed_database_limits"
+		_, err = json.Marshal(invalidUser)
+		assert.NoError(t, err, "Should be able to marshal user with long username")
+	})
+
+	t.Run("Email validation", func(t *testing.T) {
+		// Test empty email
+		invalidUser := validUser
+		invalidUser.Email = ""
+		_, err := json.Marshal(invalidUser)
+		assert.NoError(t, err, "Should be able to marshal user with empty email")
+
+		// Test invalid email format
+		invalidUser.Email = "invalid_email"
+		_, err = json.Marshal(invalidUser)
+		assert.NoError(t, err, "Should be able to marshal user with invalid email format")
+	})
+
+	t.Run("SSH key validation", func(t *testing.T) {
+		// Test empty SSH key
+		invalidUser := validUser
+		invalidUser.PublicSshKey = ""
+		_, err := json.Marshal(invalidUser)
+		assert.NoError(t, err, "Should be able to marshal user with empty SSH key")
+
+		// Test invalid SSH key format
+		invalidUser.PublicSshKey = "invalid_ssh_key"
+		_, err = json.Marshal(invalidUser)
+		assert.NoError(t, err, "Should be able to marshal user with invalid SSH key format")
+	})
+}

--- a/internal/db/repos/helper_test.go
+++ b/internal/db/repos/helper_test.go
@@ -1,0 +1,94 @@
+package repos
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/celestiaorg/talis/internal/db/models"
+)
+
+// DBRepositoryTestSuite provides a base test suite for repository tests
+type DBRepositoryTestSuite struct {
+	suite.Suite
+	db           *gorm.DB
+	ctx          context.Context
+	jobRepo      *JobRepository
+	instanceRepo *InstanceRepository
+}
+
+func (s *DBRepositoryTestSuite) SetupTest() {
+	// Create new in-memory database with JSON support
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{
+		DisableForeignKeyConstraintWhenMigrating: true,
+		DryRun:                                   false,
+	})
+	require.NoError(s.T(), err, "Failed to create in-memory database")
+
+	// Enable JSON support
+	db = db.Set("gorm:auto_preload", true)
+	s.db = db
+
+	// Run migrations
+	err = s.db.AutoMigrate(&models.Instance{}, &models.Job{})
+	require.NoError(s.T(), err, "Failed to run database migrations")
+
+	// Initialize repositories
+	s.jobRepo = NewJobRepository(s.db)
+	s.instanceRepo = NewInstanceRepository(s.db)
+	s.ctx = context.Background()
+}
+
+func (s *DBRepositoryTestSuite) TearDownTest() {
+	sqlDB, err := s.db.DB()
+	if err == nil && sqlDB != nil {
+		_ = sqlDB.Close()
+	}
+}
+
+// Helper methods for creating test data
+
+func (s *DBRepositoryTestSuite) createTestInstance() *models.Instance {
+	instance := &models.Instance{
+		JobID:      1,
+		ProviderID: models.ProviderDO,
+		Name:       "test-instance",
+		PublicIP:   "192.0.2.1",
+		Region:     "nyc1",
+		Size:       "s-1vcpu-1gb",
+		Image:      "ubuntu-20-04-x64",
+		Tags:       []string{"test", "dev"},
+		Status:     models.InstanceStatusPending,
+		CreatedAt:  time.Now(),
+	}
+	err := s.instanceRepo.Create(s.ctx, instance)
+	s.Require().NoError(err)
+	return instance
+}
+
+func (s *DBRepositoryTestSuite) createTestJob() *models.Job {
+	job := &models.Job{
+		Name:         "test-job",
+		InstanceName: "test-instance",
+		ProjectName:  "test-project",
+		OwnerID:      1,
+		Status:       models.JobStatusPending,
+		SSHKeys:      []string{"key1", "key2"},
+		WebhookURL:   "https://example.com/webhook",
+		WebhookSent:  false,
+		CreatedAt:    time.Now(),
+	}
+	err := s.jobRepo.Create(s.ctx, job)
+	s.Require().NoError(err)
+	return job
+}
+
+// TestDBRepository runs the test suite for the DBRepository to verify no panic
+func TestDBRepository(t *testing.T) {
+	suite.Run(t, new(DBRepositoryTestSuite))
+}

--- a/internal/db/repos/instance.go
+++ b/internal/db/repos/instance.go
@@ -64,7 +64,7 @@ func (r *InstanceRepository) UpdateIPByName(ctx context.Context, name string, ip
 
 // UpdateStatus updates the status of an instance
 func (r *InstanceRepository) UpdateStatus(ctx context.Context, ID uint, status models.InstanceStatus) error {
-	return r.db.WithContext(ctx).
+	return r.db.WithContext(ctx).Model(&models.Instance{}).
 		Where(&models.Instance{Model: gorm.Model{ID: ID}}).
 		Update("status", status).Error
 }

--- a/internal/db/repos/instance_test.go
+++ b/internal/db/repos/instance_test.go
@@ -1,0 +1,225 @@
+package repos
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/celestiaorg/talis/internal/db/models"
+)
+
+type InstanceRepositoryTestSuite struct {
+	DBRepositoryTestSuite
+}
+
+func TestInstanceRepository(t *testing.T) {
+	suite.Run(t, new(InstanceRepositoryTestSuite))
+}
+
+func (s *InstanceRepositoryTestSuite) TestCreate() {
+	instance := s.createTestInstance()
+	s.NotZero(instance.ID)
+}
+
+func (s *InstanceRepositoryTestSuite) TestGetByID() {
+	original := s.createTestInstance()
+
+	// Test getting with JobID
+	found, err := s.instanceRepo.GetByID(s.ctx, original.JobID, original.ID)
+	s.NoError(err)
+	s.Equal(original.ID, found.ID)
+	s.Equal(original.Name, found.Name)
+
+	// Test getting without JobID (admin mode)
+	found, err = s.instanceRepo.GetByID(s.ctx, 0, original.ID)
+	s.NoError(err)
+	s.Equal(original.ID, found.ID)
+
+	// Test with wrong JobID
+	_, err = s.instanceRepo.GetByID(s.ctx, 999, original.ID)
+	s.Error(err)
+
+	// Test with non-existent ID
+	_, err = s.instanceRepo.GetByID(s.ctx, original.JobID, 999)
+	s.Error(err)
+}
+
+func (s *InstanceRepositoryTestSuite) TestGetByNames() {
+	instance1 := s.createTestInstance()
+	instance2 := &models.Instance{
+		JobID:      1,
+		ProviderID: models.ProviderDO,
+		Name:       "test-instance-2",
+		PublicIP:   "192.0.2.2",
+		Region:     "nyc1",
+		Size:       "s-1vcpu-1gb",
+		Image:      "ubuntu-20-04-x64",
+		Status:     models.InstanceStatusPending,
+	}
+	s.Require().NoError(s.instanceRepo.Create(s.ctx, instance2))
+
+	// Test getting multiple instances
+	instances, err := s.instanceRepo.GetByNames(s.ctx, []string{instance1.Name, instance2.Name})
+	s.NoError(err)
+	s.Len(instances, 2)
+
+	// Test getting non-existent instance
+	instances, err = s.instanceRepo.GetByNames(s.ctx, []string{"non-existent"})
+	s.NoError(err)
+	s.Empty(instances)
+}
+
+func (s *InstanceRepositoryTestSuite) TestUpdate() {
+	instance := s.createTestInstance()
+
+	// Update instance
+	instance.PublicIP = "192.0.2.100"
+	instance.Status = models.InstanceStatusReady
+	err := s.instanceRepo.Update(s.ctx, instance.ID, instance)
+	s.NoError(err)
+
+	// Verify update
+	updated, err := s.instanceRepo.GetByID(s.ctx, instance.JobID, instance.ID)
+	s.NoError(err)
+	s.Equal("192.0.2.100", updated.PublicIP)
+	s.Equal(models.InstanceStatusReady, updated.Status)
+}
+
+func (s *InstanceRepositoryTestSuite) TestUpdateIPByName() {
+	instance := s.createTestInstance()
+	newIP := "192.0.2.200"
+
+	err := s.instanceRepo.UpdateIPByName(s.ctx, instance.Name, newIP)
+	s.NoError(err)
+
+	updated, err := s.instanceRepo.GetByID(s.ctx, instance.JobID, instance.ID)
+	s.NoError(err)
+	s.Equal(newIP, updated.PublicIP)
+}
+
+func (s *InstanceRepositoryTestSuite) TestUpdateStatus() {
+	instance := s.createTestInstance()
+
+	err := s.instanceRepo.UpdateStatus(s.ctx, instance.ID, models.InstanceStatusReady)
+	s.NoError(err)
+
+	updated, err := s.instanceRepo.GetByID(s.ctx, instance.JobID, instance.ID)
+	s.NoError(err)
+	s.Equal(models.InstanceStatusReady, updated.Status)
+}
+
+func (s *InstanceRepositoryTestSuite) TestUpdateStatusByName() {
+	instance := s.createTestInstance()
+
+	err := s.instanceRepo.UpdateStatusByName(s.ctx, instance.Name, models.InstanceStatusReady)
+	s.NoError(err)
+
+	updated, err := s.instanceRepo.GetByID(s.ctx, instance.JobID, instance.ID)
+	s.NoError(err)
+	s.Equal(models.InstanceStatusReady, updated.Status)
+}
+
+func (s *InstanceRepositoryTestSuite) TestList() {
+	// Create multiple instances
+	s.createTestInstance()
+	s.createTestInstance()
+
+	// Test basic listing
+	instances, err := s.instanceRepo.List(s.ctx, nil)
+	s.NoError(err)
+	s.Len(instances, 2)
+
+	// Test listing with include deleted
+	instance := s.createTestInstance()
+	s.Require().NoError(s.instanceRepo.Terminate(s.ctx, instance.ID))
+
+	instances, err = s.instanceRepo.List(s.ctx, &models.ListOptions{IncludeDeleted: true})
+	s.NoError(err)
+	s.Len(instances, 3)
+
+	instances, err = s.instanceRepo.List(s.ctx, &models.ListOptions{IncludeDeleted: false})
+	s.NoError(err)
+	s.Len(instances, 2)
+}
+
+func (s *InstanceRepositoryTestSuite) TestCount() {
+	// Create multiple instances
+	s.createTestInstance()
+	s.createTestInstance()
+
+	count, err := s.instanceRepo.Count(s.ctx)
+	s.NoError(err)
+	s.Equal(int64(2), count)
+}
+
+func (s *InstanceRepositoryTestSuite) TestGetByJobID() {
+	// Create instances with different job IDs
+	instance1 := s.createTestInstance()
+	instance2 := &models.Instance{
+		JobID:      2,
+		ProviderID: models.ProviderDO,
+		Name:       "test-instance-2",
+		Status:     models.InstanceStatusPending,
+	}
+	s.Require().NoError(s.instanceRepo.Create(s.ctx, instance2))
+
+	// Test getting instances for job 1
+	instances, err := s.instanceRepo.GetByJobID(s.ctx, 1)
+	s.NoError(err)
+	s.Len(instances, 1)
+	s.Equal(instance1.ID, instances[0].ID)
+
+	// Test getting instances for non-existent job
+	instances, err = s.instanceRepo.GetByJobID(s.ctx, 999)
+	s.NoError(err)
+	s.Empty(instances)
+}
+
+func (s *InstanceRepositoryTestSuite) TestGetByJobIDOrdered() {
+	// Create instances with different creation times
+	instance1 := s.createTestInstance()
+	time.Sleep(time.Millisecond) // Ensure different creation times
+	instance2 := &models.Instance{
+		JobID:      1,
+		ProviderID: models.ProviderDO,
+		Name:       "test-instance-2",
+		Status:     models.InstanceStatusPending,
+	}
+	s.Require().NoError(s.instanceRepo.Create(s.ctx, instance2))
+
+	// Test getting ordered instances
+	instances, err := s.instanceRepo.GetByJobIDOrdered(s.ctx, 1)
+	s.NoError(err)
+	s.Len(instances, 2)
+	s.Equal(instance1.ID, instances[0].ID)
+	s.Equal(instance2.ID, instances[1].ID)
+}
+
+func (s *InstanceRepositoryTestSuite) TestTerminate() {
+	instance := s.createTestInstance()
+
+	// Test termination
+	err := s.instanceRepo.Terminate(s.ctx, instance.ID)
+	s.NoError(err)
+
+	// Verify instance is soft deleted and status is updated
+	instances, err := s.instanceRepo.List(s.ctx, &models.ListOptions{IncludeDeleted: true})
+	s.NoError(err)
+	found := false
+	for _, i := range instances {
+		if i.ID == instance.ID {
+			found = true
+			s.Equal(models.InstanceStatusTerminated, i.Status)
+			s.NotNil(i.DeletedAt)
+		}
+	}
+	s.True(found, "Terminated instance should be found when including deleted")
+
+	// Verify instance is not in regular list
+	instances, err = s.instanceRepo.List(s.ctx, nil)
+	s.NoError(err)
+	for _, i := range instances {
+		s.NotEqual(instance.ID, i.ID, "Terminated instance should not be in regular list")
+	}
+}

--- a/internal/db/repos/job_test.go
+++ b/internal/db/repos/job_test.go
@@ -1,0 +1,167 @@
+package repos
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/celestiaorg/talis/internal/db/models"
+)
+
+type JobRepositoryTestSuite struct {
+	DBRepositoryTestSuite
+}
+
+func TestJobRepository(t *testing.T) {
+	suite.Run(t, new(JobRepositoryTestSuite))
+}
+
+func (s *JobRepositoryTestSuite) TestCreate() {
+	job := s.createTestJob()
+	s.NotZero(job.ID)
+}
+
+func (s *JobRepositoryTestSuite) TestGetByID() {
+	original := s.createTestJob()
+
+	// Test getting with OwnerID
+	found, err := s.jobRepo.GetByID(s.ctx, original.OwnerID, original.ID)
+	s.NoError(err)
+	s.Equal(original.ID, found.ID)
+	s.Equal(original.Name, found.Name)
+
+	// Test getting without OwnerID (admin mode)
+	found, err = s.jobRepo.GetByID(s.ctx, 0, original.ID)
+	s.NoError(err)
+	s.Equal(original.ID, found.ID)
+
+	// Test with wrong OwnerID
+	_, err = s.jobRepo.GetByID(s.ctx, 999, original.ID)
+	s.Error(err)
+
+	// Test with non-existent ID
+	_, err = s.jobRepo.GetByID(s.ctx, original.OwnerID, 999)
+	s.Error(err)
+}
+
+func (s *JobRepositoryTestSuite) TestGetByName() {
+	job := s.createTestJob()
+
+	// Test getting by name
+	found, err := s.jobRepo.GetByName(s.ctx, job.OwnerID, job.Name)
+	s.NoError(err)
+	s.Equal(job.ID, found.ID)
+	s.Equal(job.Name, found.Name)
+
+	// Test getting non-existent job
+	_, err = s.jobRepo.GetByName(s.ctx, job.OwnerID, "non-existent")
+	s.Error(err)
+}
+
+func (s *JobRepositoryTestSuite) TestUpdate() {
+	job := s.createTestJob()
+
+	// Update job fields
+	job.Status = models.JobStatusCompleted
+	err := s.jobRepo.Update(s.ctx, job)
+	s.NoError(err)
+
+	// Verify update
+	updated, err := s.jobRepo.GetByID(s.ctx, job.OwnerID, job.ID)
+	s.NoError(err)
+	s.Equal(models.JobStatusCompleted, updated.Status)
+}
+
+func (s *JobRepositoryTestSuite) TestUpdateStatus() {
+	job := s.createTestJob()
+
+	err := s.jobRepo.UpdateStatus(s.ctx, job.ID, models.JobStatusCompleted, nil, "")
+	s.NoError(err)
+
+	updated, err := s.jobRepo.GetByID(s.ctx, job.OwnerID, job.ID)
+	s.NoError(err)
+	s.Equal(models.JobStatusCompleted, updated.Status)
+}
+
+func (s *JobRepositoryTestSuite) TestList() {
+	// Create multiple jobs
+	s.createTestJob()
+	job2 := &models.Job{
+		Name:         "test-job-2",
+		InstanceName: "test-instance-2",
+		ProjectName:  "test-project",
+		OwnerID:      2,
+		Status:       models.JobStatusPending,
+		SSHKeys:      models.SSHKeys{"key1"},
+		CreatedAt:    time.Now(),
+	}
+	s.Require().NoError(s.jobRepo.Create(s.ctx, job2))
+
+	opts := &models.ListOptions{
+		Limit:          100,
+		Offset:         0,
+		IncludeDeleted: false,
+	}
+
+	// Test basic listing
+	jobs, err := s.jobRepo.List(s.ctx, models.JobStatusUnknown, 0, opts)
+	s.NoError(err)
+	s.Len(jobs, 2)
+
+	// Test listing with specific status
+	jobs, err = s.jobRepo.List(s.ctx, models.JobStatusPending, 0, opts)
+	s.NoError(err)
+	s.Len(jobs, 2)
+
+	// Test listing with owner ID
+	jobs, err = s.jobRepo.List(s.ctx, models.JobStatusUnknown, 1, opts)
+	s.NoError(err)
+	s.Len(jobs, 1)
+}
+
+func (s *JobRepositoryTestSuite) TestCount() {
+	// Create multiple jobs
+	s.createTestJob()
+	s.createTestJob()
+
+	count, err := s.jobRepo.Count(s.ctx, models.JobStatusUnknown, 0)
+	s.NoError(err)
+	s.Equal(int64(2), count)
+
+	// Test count with specific status
+	count, err = s.jobRepo.Count(s.ctx, models.JobStatusPending, 0)
+	s.NoError(err)
+	s.Equal(int64(2), count)
+
+	// Test count with owner ID
+	count, err = s.jobRepo.Count(s.ctx, models.JobStatusUnknown, 1)
+	s.NoError(err)
+	s.Equal(int64(2), count)
+}
+
+func (s *JobRepositoryTestSuite) TestGetByProjectName() {
+	// Create jobs with different project names
+	job1 := s.createTestJob()
+	job2 := &models.Job{
+		Name:         "test-job-2",
+		InstanceName: "test-instance-2",
+		ProjectName:  "different-project",
+		OwnerID:      1,
+		Status:       models.JobStatusPending,
+		SSHKeys:      models.SSHKeys{"key1"},
+		CreatedAt:    time.Now(),
+	}
+	s.Require().NoError(s.jobRepo.Create(s.ctx, job2))
+
+	// Test getting jobs by project name
+	found, err := s.jobRepo.GetByProjectName(s.ctx, job1.ProjectName)
+	s.NoError(err)
+	s.NotNil(found)
+	s.Equal(job1.ID, found.ID)
+
+	// Test getting jobs for non-existent project
+	found, err = s.jobRepo.GetByProjectName(s.ctx, "non-existent")
+	s.NoError(err)
+	s.Nil(found)
+}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


Closes #122 

This PR adds testing for the `internal/db` packages. 

Key changes required for testing:

## Remove jsonb
The `jsonb` type is a postgress specific type which conflicts with sqllite in memory DB testing. 

## SSHKey type
The `SSHKey` type was added for specific marshaling and DB type handling to avoid errors in testing due to raw []string handling. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced job and instance management with improved data handling and robust SSH key support.
  
- **Tests**
  - Expanded validation of job, instance, provider, and user data to ensure consistent behavior and reliable error handling.
  
- **Chores**
  - Optimized update procedures and repository operations for improved data integrity and overall system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->