### PR TITLE
feat: distinguish between instance status and job status in list options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ GOBUILD := $(GO) build
 PKG ?= ./...
 TEST ?= .
 TEST_FLAGS ?= -v
+COUNT ?= 1
 
 # Build flags
 LDFLAGS := -ldflags="-s -w"
@@ -53,7 +54,7 @@ clean:
 #   make test PKG=./internal/auth TEST=TestLogin  # Run TestLogin in auth package
 test:
 	@echo "Running tests..."
-	$(GOTEST) $(TEST_FLAGS) -run="$(TEST)" $(PKG)
+	$(GOTEST) $(TEST_FLAGS) -run="$(TEST)" -count=$(COUNT) $(PKG)
 .PHONY: test
 
 ## fmt: Format code

--- a/internal/api/v1/client/client.go
+++ b/internal/api/v1/client/client.go
@@ -208,17 +208,25 @@ func getQueryParams(opts *models.ListOptions) (url.Values, error) {
 		return q, nil
 	}
 
-	if opts.IncludeDeleted {
-		q.Set("include_deleted", "true")
-	}
+	// Pagination params
 	if opts.Limit > 0 {
 		q.Set("limit", fmt.Sprintf("%d", opts.Limit))
 	}
 	if opts.Offset > 0 {
 		q.Set("offset", fmt.Sprintf("%d", opts.Offset))
 	}
-	if opts.Status != nil {
-		status := *opts.Status
+
+	// Filtering params
+	if opts.IncludeDeleted {
+		q.Set("include_deleted", "true")
+	}
+	if opts.StatusFilter != "" {
+		q.Set("status_filter", string(opts.StatusFilter))
+	}
+
+	// Instance status params
+	if opts.InstanceStatus != nil {
+		status := *opts.InstanceStatus
 		var statusStr string
 		switch status {
 		case models.InstanceStatusUnknown:
@@ -234,12 +242,33 @@ func getQueryParams(opts *models.ListOptions) (url.Values, error) {
 		default:
 			return nil, fmt.Errorf("invalid instance status: %d", status)
 		}
-		q.Set("status", statusStr)
+		q.Set("instance_status", statusStr)
 	}
-
-	// Add status_filter if provided, regardless of status value
-	if opts.StatusFilter != "" {
-		q.Set("status_filter", string(opts.StatusFilter))
+	// Job status params
+	if opts.JobStatus != nil {
+		status := *opts.JobStatus
+		var statusStr string
+		switch status {
+		case models.JobStatusUnknown:
+			statusStr = "unknown"
+		case models.JobStatusPending:
+			statusStr = "pending"
+		case models.JobStatusInitializing:
+			statusStr = "initializing"
+		case models.JobStatusProvisioning:
+			statusStr = "provisioning"
+		case models.JobStatusConfiguring:
+			statusStr = "configuring"
+		case models.JobStatusDeleting:
+			statusStr = "deleting"
+		case models.JobStatusCompleted:
+			statusStr = "completed"
+		case models.JobStatusFailed:
+			statusStr = "failed"
+		default:
+			return nil, fmt.Errorf("invalid job status: %v", status)
+		}
+		q.Set("job_status", statusStr)
 	}
 
 	return q, nil

--- a/internal/api/v1/client/client_test.go
+++ b/internal/api/v1/client/client_test.go
@@ -235,7 +235,7 @@ func TestGetQueryParams(t *testing.T) {
 			},
 		},
 		{
-			name: "include deleted only",
+			name: "include deleted true",
 			opts: &models.ListOptions{
 				IncludeDeleted: true,
 			},
@@ -244,74 +244,69 @@ func TestGetQueryParams(t *testing.T) {
 			},
 		},
 		{
-			name: "status ready",
+			name: "include deleted false",
 			opts: &models.ListOptions{
-				Status: func() *models.InstanceStatus {
-					s := models.InstanceStatusReady
-					return &s
-				}(),
+				IncludeDeleted: false,
 			},
-			want: map[string][]string{
-				"status": {"ready"},
-			},
+			want: map[string][]string{},
 		},
 		{
-			name: "status terminated",
+			name: "status filter equal",
 			opts: &models.ListOptions{
-				Status: func() *models.InstanceStatus {
-					s := models.InstanceStatusTerminated
-					return &s
-				}(),
-			},
-			want: map[string][]string{
-				"status": {"terminated"},
-			},
-		},
-		{
-			name: "all options with status filter equal",
-			opts: &models.ListOptions{
-				Limit:          10,
-				Offset:         20,
-				IncludeDeleted: true,
-				Status: func() *models.InstanceStatus {
-					s := models.InstanceStatusReady
-					return &s
-				}(),
 				StatusFilter: models.StatusFilterEqual,
 			},
 			want: map[string][]string{
-				"limit":           {"10"},
-				"offset":          {"20"},
-				"include_deleted": {"true"},
-				"status":          {"ready"},
-				"status_filter":   {"equal"},
+				"status_filter": {"equal"},
 			},
 		},
 		{
-			name: "all options with status filter not equal",
+			name: "status filter not equal",
 			opts: &models.ListOptions{
-				Limit:          10,
-				Offset:         20,
-				IncludeDeleted: true,
-				Status: func() *models.InstanceStatus {
-					s := models.InstanceStatusTerminated
-					return &s
-				}(),
 				StatusFilter: models.StatusFilterNotEqual,
 			},
 			want: map[string][]string{
-				"limit":           {"10"},
-				"offset":          {"20"},
-				"include_deleted": {"true"},
-				"status":          {"terminated"},
-				"status_filter":   {"not_equal"},
+				"status_filter": {"not_equal"},
 			},
 		},
 		{
-			name: "invalid status",
+			name: "instance status test",
 			opts: &models.ListOptions{
-				Status: func() *models.InstanceStatus {
+				InstanceStatus: func() *models.InstanceStatus {
+					s := models.InstanceStatusReady
+					return &s
+				}(),
+			},
+			want: map[string][]string{
+				"instance_status": {"ready"},
+			},
+		},
+		{
+			name: "job status test",
+			opts: &models.ListOptions{
+				JobStatus: func() *models.JobStatus {
+					s := models.JobStatusCompleted
+					return &s
+				}(),
+			},
+			want: map[string][]string{
+				"job_status": {"completed"},
+			},
+		},
+		{
+			name: "invalid instance status",
+			opts: &models.ListOptions{
+				InstanceStatus: func() *models.InstanceStatus {
 					s := models.InstanceStatus(999)
+					return &s
+				}(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid job status",
+			opts: &models.ListOptions{
+				JobStatus: func() *models.JobStatus {
+					s := models.JobStatus("invalid")
 					return &s
 				}(),
 			},
@@ -323,11 +318,11 @@ func TestGetQueryParams(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := getQueryParams(tt.opts)
 			if tt.wantErr {
-				require.Error(t, err)
+				require.Error(t, err, tt.name)
 				return
 			}
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, map[string][]string(got))
+			require.NoError(t, err, tt.name)
+			assert.Equal(t, tt.want, map[string][]string(got), tt.name)
 		})
 	}
 }

--- a/internal/api/v1/handlers/instance.go
+++ b/internal/api/v1/handlers/instance.go
@@ -36,11 +36,11 @@ func (h *InstanceHandler) ListInstances(c *fiber.Ctx) error {
 			return c.Status(fiber.StatusBadRequest).
 				JSON(infrastructure.ErrInvalidInput(fmt.Sprintf("invalid instance status: %v", err)))
 		}
-		opts.Status = &status
-	} else if !opts.IncludeDeleted && opts.Status == nil {
+		opts.InstanceStatus = &status
+	} else if !opts.IncludeDeleted && opts.InstanceStatus == nil {
 		// By default, exclude terminated instances if not including deleted
 		defaultStatus := models.InstanceStatusTerminated
-		opts.Status = &defaultStatus
+		opts.InstanceStatus = &defaultStatus
 		opts.StatusFilter = models.StatusFilterNotEqual
 	}
 
@@ -121,9 +121,9 @@ func (h *InstanceHandler) GetPublicIPs(c *fiber.Ctx) error {
 	opts.IncludeDeleted = c.QueryBool("include_deleted", false)
 
 	// Only apply default status filter if IncludeDeleted is false
-	if !opts.IncludeDeleted && opts.Status == nil {
+	if !opts.IncludeDeleted && opts.InstanceStatus == nil {
 		defaultStatus := models.InstanceStatusTerminated
-		opts.Status = &defaultStatus
+		opts.InstanceStatus = &defaultStatus
 		opts.StatusFilter = models.StatusFilterNotEqual
 	}
 
@@ -169,9 +169,9 @@ func (h *InstanceHandler) GetAllMetadata(c *fiber.Ctx) error {
 	opts.IncludeDeleted = c.QueryBool("include_deleted", false)
 
 	// Only apply default status filter if IncludeDeleted is false
-	if !opts.IncludeDeleted && opts.Status == nil {
+	if !opts.IncludeDeleted && opts.InstanceStatus == nil {
 		defaultStatus := models.InstanceStatusTerminated
-		opts.Status = &defaultStatus
+		opts.InstanceStatus = &defaultStatus
 		opts.StatusFilter = models.StatusFilterNotEqual
 	}
 
@@ -277,7 +277,7 @@ func (h *InstanceHandler) GetInstances(c *fiber.Ctx) error {
 				"error": fmt.Sprintf("invalid instance status: %v", err),
 			})
 		}
-		opts.Status = &status
+		opts.InstanceStatus = &status
 	}
 
 	instances, err := h.service.ListInstances(c.Context(), &opts)

--- a/internal/api/v1/services/instance.go
+++ b/internal/api/v1/services/instance.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -209,27 +210,33 @@ func (s *Instance) Terminate(ctx context.Context, ownerID uint, jobName string, 
 	return nil
 }
 
-// handleInfrastructureDeletion handles the infrastructure deletion process
+// deleteRequest represents a single instance deletion request with tracking
+type deleteRequest struct {
+	instance     models.Instance
+	infraRequest *infrastructure.InstancesRequest
+	attempts     int
+	lastError    error
+	maxAttempts  int
+}
+
+// deletionResults tracks the overall results of the deletion operation
+type deletionResults struct {
+	successful []string         // names of successfully deleted instances
+	failed     map[string]error // instance name -> last error for failed deletions
+}
+
+// terminate handles the infrastructure deletion process
 func (s *Instance) terminate(ctx context.Context, jobName string, instances []models.Instance) {
 	go func() {
 		if len(instances) == 0 {
-			fmt.Printf("❌ No instances found to terminate\n")
+			fmt.Printf("❌ No instances provided to terminate\n")
 			return
 		}
 
-		// Prepare deletion result
-		deletionResult := map[string]interface{}{
-			"status":  "deleting",
-			"deleted": []string{},
-		}
-
-		// Try to delete each selected instance
-		// TODO: Consider async deletion in multiple goroutines
+		// Create queue of delete requests
+		queue := make([]*deleteRequest, 0, len(instances))
 		for _, instance := range instances {
-			fmt.Printf("🗑️ Attempting to delete instance: %s\n", instance.Name)
-
-			// Create a new infrastructure request for each instance
-			instanceInfraReq := &infrastructure.InstancesRequest{
+			infraReq := &infrastructure.InstancesRequest{
 				JobName: jobName,
 				Instances: []infrastructure.InstanceRequest{
 					{
@@ -241,50 +248,101 @@ func (s *Instance) terminate(ctx context.Context, jobName string, instances []mo
 				},
 				Action: "delete",
 			}
-
 			// TODO: a hacky fix, but has to be addressed properly in another PR
-			if instanceInfraReq.Provider == "" {
-				instanceInfraReq.Provider = instanceInfraReq.Instances[0].Provider
+			if infraReq.Provider == "" {
+				infraReq.Provider = infraReq.Instances[0].Provider
 			}
 
-			// Create infrastructure client for this specific instance
-			infra, err := infrastructure.NewInfrastructure(instanceInfraReq)
-			if err != nil {
-				fmt.Printf("❌ Failed to create infrastructure client for instance %s: %v\n", instance.Name, err)
-				continue
-			}
+			queue = append(queue, &deleteRequest{
+				instance:     instance,
+				infraRequest: infraReq,
+				maxAttempts:  10,
+			})
+		}
 
-			// Execute the deletion for this specific instance
-			_, err = infra.Execute()
-			if err != nil {
-				if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
-					fmt.Printf("⚠️ Warning: Instance %s was already deleted\n", instance.Name)
-					// Instance doesn't exist in DO, safe to mark as deleted
-					if err := s.repo.Terminate(ctx, instance.ID); err != nil {
-						fmt.Printf("❌ Failed to mark instance %s as terminated in database: %v\n", instance.Name, err)
-						continue
-					}
-					fmt.Printf("✅ Marked instance %s as terminated in database\n", instance.Name)
-					if deleted, ok := deletionResult["deleted"].([]string); ok {
-						deletionResult["deleted"] = append(deleted, instance.Name)
-					}
-				} else {
-					fmt.Printf("❌ Error deleting instance %s: %v\n", instance.Name, err)
-					continue
+		results := &deletionResults{
+			successful: make([]string, 0),
+			failed:     make(map[string]error),
+		}
+
+		// Process queue until empty or all requests have failed
+		defaultErrorSleep := 100 * time.Millisecond
+	REQUESTLOOP:
+		for len(queue) > 0 {
+			select {
+			case <-ctx.Done():
+				// Context cancelled, mark remaining requests as failed
+				for _, req := range queue {
+					results.failed[req.instance.Name] = fmt.Errorf("operation cancelled: %w", ctx.Err())
 				}
+				queue = nil // Clear the queue
+				break REQUESTLOOP
+			default:
 			}
 
-			// Deletion was successful, update database
-			if err := s.repo.Terminate(ctx, instance.ID); err != nil {
-				fmt.Printf("❌ Failed to mark instance %s as terminated in database: %v\n", instance.Name, err)
+			request := queue[0]
+			queue = queue[1:] // pop from front
+
+			// Skip if max attempts reached
+			if request.attempts >= request.maxAttempts {
+				results.failed[request.instance.Name] = fmt.Errorf("max attempts reached (%d): %w", request.maxAttempts, request.lastError)
 				continue
 			}
-			fmt.Printf("✅ Marked instance %s as terminated in database\n", instance.Name)
-			if deleted, ok := deletionResult["deleted"].([]string); ok {
-				deletionResult["deleted"] = append(deleted, instance.Name)
+
+			request.attempts++
+
+			// Try to delete infrastructure
+			infra, err := infrastructure.NewInfrastructure(request.infraRequest)
+			if err != nil {
+				request.lastError = fmt.Errorf("failed to create infrastructure client: %w", err)
+				queue = append(queue, request) // add back to queue
+				time.Sleep(defaultErrorSleep)
+				continue
+			}
+
+			_, err = infra.Execute()
+			// If error exists and it's not a "not found" error, add back to queue
+			if err != nil && !(strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found")) {
+				request.lastError = fmt.Errorf("failed to delete infrastructure: %w", err)
+				queue = append(queue, request) // add back to queue
+				time.Sleep(defaultErrorSleep)
+				continue
+			}
+
+			// Try to update database
+			if err := s.repo.Terminate(ctx, request.instance.ID); err != nil {
+				request.lastError = fmt.Errorf("failed to terminate in database: %w", err)
+				queue = append(queue, request) // add back to queue
+				time.Sleep(defaultErrorSleep)
+				continue
+			}
+
+			// Successfully deleted both infrastructure and database record
+			results.successful = append(results.successful, request.instance.Name)
+		}
+
+		// Log final results
+		if len(results.successful) > 0 {
+			logger.Infof("Successfully deleted instances: %v", results.successful)
+		}
+		if len(results.failed) > 0 {
+			logger.Infof("Failed to delete instances:")
+			for name, err := range results.failed {
+				logger.Infof("  %s: %v", name, err)
 			}
 		}
 
-		deletionResult["status"] = "completed"
+		// Update deletion result for API response
+		deletionResult := map[string]interface{}{
+			"status":    "completed",
+			"deleted":   results.successful,
+			"failed":    results.failed,
+			"completed": time.Now().UTC(),
+		}
+
+		// Update final status with result
+		if err := s.jobService.UpdateJobStatus(ctx, instances[0].JobID, models.JobStatusCompleted, deletionResult, ""); err != nil {
+			logger.Errorf("Failed to update final job status: %v", err)
+		}
 	}()
 }

--- a/internal/api/v1/services/instance.go
+++ b/internal/api/v1/services/instance.go
@@ -132,18 +132,16 @@ func (s *Instance) provisionInstances(ctx context.Context, jobID uint, instances
 
 		// Update instance information in database
 		for _, instance := range pInstances {
-			// Update IP and status
-			if err := s.repo.UpdateIPByName(ctx, instance.Name, instance.IP); err != nil {
-				fmt.Printf("❌ Failed to update instance %s IP: %v\n", instance.Name, err)
+			// Create update instance with only the fields we want to update
+			updateInstance := &models.Instance{
+				PublicIP: instance.IP,
+				Status:   models.InstanceStatusReady,
+			}
+			if err := s.repo.UpdateByName(ctx, instance.Name, updateInstance); err != nil {
+				fmt.Printf("❌ Failed to update instance %s: %v\n", instance.Name, err)
 				continue
 			}
-			fmt.Printf("✅ Updated instance %s with IP %s\n", instance.Name, instance.IP)
-
-			if err := s.repo.UpdateStatusByName(ctx, instance.Name, models.InstanceStatusReady); err != nil {
-				fmt.Printf("❌ Failed to update instance %s status: %v\n", instance.Name, err)
-				continue
-			}
-			fmt.Printf("✅ Updated instance %s status to ready\n", instance.Name)
+			fmt.Printf("✅ Updated instance %s with IP %s and status ready\n", instance.Name, instance.IP)
 		}
 
 		// Start Ansible provisioning if requested

--- a/internal/db/models/models.go
+++ b/internal/db/models/models.go
@@ -1,6 +1,6 @@
 package models
 
-// StatusFilter represents how to filter instances by status
+// StatusFilter represents how to filter db items by status
 type StatusFilter string
 
 const (
@@ -12,9 +12,13 @@ const (
 
 // ListOptions represents pagination and filtering options for list operations
 type ListOptions struct {
-	Limit          int             `json:"limit"`  // Number of items to return
-	Offset         int             `json:"offset"` // Number of items to skip
-	IncludeDeleted bool            `json:"include_deleted"`
-	Status         *InstanceStatus `json:"status,omitempty"`        // Filter by instance status
-	StatusFilter   StatusFilter    `json:"status_filter,omitempty"` // How to filter by status
+	// Pagination
+	Limit  int `json:"limit"`  // Number of items to return
+	Offset int `json:"offset"` // Number of items to skip
+	// Filtering
+	IncludeDeleted bool         `json:"include_deleted"`
+	StatusFilter   StatusFilter `json:"status_filter,omitempty"` // How to filter by status
+	// Statuses
+	InstanceStatus *InstanceStatus `json:"instance_status,omitempty"` // Filter by instance status
+	JobStatus      *JobStatus      `json:"job_status,omitempty"`      // Filter by job status
 }

--- a/internal/db/repos/instance.go
+++ b/internal/db/repos/instance.go
@@ -83,11 +83,11 @@ func (r *InstanceRepository) applyListOptions(query *gorm.DB, opts *models.ListO
 	}
 
 	// Apply status filter if provided
-	if opts.Status != nil {
+	if opts.InstanceStatus != nil {
 		if opts.StatusFilter == models.StatusFilterNotEqual {
-			query = query.Where("status != ?", *opts.Status)
+			query = query.Where("status != ?", *opts.InstanceStatus)
 		} else {
-			query = query.Where("status = ?", *opts.Status)
+			query = query.Where("status = ?", *opts.InstanceStatus)
 		}
 	} else if !opts.IncludeDeleted {
 		// By default, only show non-terminated instances if not including deleted

--- a/internal/db/repos/instance.go
+++ b/internal/db/repos/instance.go
@@ -50,30 +50,35 @@ func (r *InstanceRepository) GetByNames(ctx context.Context, names []string) ([]
 	return instances, nil
 }
 
-// Update updates an instance
-func (r *InstanceRepository) Update(ctx context.Context, ID uint, instance *models.Instance) error {
-	return r.db.WithContext(ctx).Where(&models.Instance{Model: gorm.Model{ID: ID}}).Updates(instance).Error
+// UpdateByID updates an instance by its ID. Only non-zero fields in the instance parameter will be updated.
+// GORM's Updates method will:
+// - Only update fields with non-zero values in the instance parameter
+// - Ignore zero-value fields (null, 0, "", false)
+// - Not update fields marked with gorm:"-" tag
+// - Not update CreatedAt field
+// - Automatically update UpdatedAt if it exists
+func (r *InstanceRepository) UpdateByID(ctx context.Context, id uint, instance *models.Instance) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&models.Instance{}).
+			Where(&models.Instance{Model: gorm.Model{ID: id}}).
+			Updates(instance).Error; err != nil {
+			return fmt.Errorf("failed to update instance by ID: %w", err)
+		}
+		return nil
+	})
 }
 
-// UpdateIPByName updates the public IP of an instance by its name
-func (r *InstanceRepository) UpdateIPByName(ctx context.Context, name string, ip string) error {
-	return r.db.WithContext(ctx).Model(&models.Instance{}).
-		Where(&models.Instance{Name: name}).
-		Update(models.InstancePublicIPField, ip).Error
-}
-
-// UpdateStatus updates the status of an instance
-func (r *InstanceRepository) UpdateStatus(ctx context.Context, ID uint, status models.InstanceStatus) error {
-	return r.db.WithContext(ctx).Model(&models.Instance{}).
-		Where(&models.Instance{Model: gorm.Model{ID: ID}}).
-		Update("status", status).Error
-}
-
-// UpdateStatusByName updates the status of an instance by its name
-func (r *InstanceRepository) UpdateStatusByName(ctx context.Context, name string, status models.InstanceStatus) error {
-	return r.db.WithContext(ctx).Model(&models.Instance{}).
-		Where(&models.Instance{Name: name}).
-		Update("status", status).Error
+// UpdateByName updates an instance by its name. Only non-zero fields in the instance parameter will be updated.
+// See UpdateByID method for details on how GORM handles field updates.
+func (r *InstanceRepository) UpdateByName(ctx context.Context, name string, instance *models.Instance) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&models.Instance{}).
+			Where(&models.Instance{Name: name}).
+			Updates(instance).Error; err != nil {
+			return fmt.Errorf("failed to update instance by name: %w", err)
+		}
+		return nil
+	})
 }
 
 // applyListOptions applies the list options to the given query

--- a/internal/db/repos/instance_test.go
+++ b/internal/db/repos/instance_test.go
@@ -75,9 +75,11 @@ func (s *InstanceRepositoryTestSuite) TestUpdate() {
 	instance := s.createTestInstance()
 
 	// Update instance
-	instance.PublicIP = "192.0.2.100"
-	instance.Status = models.InstanceStatusReady
-	err := s.instanceRepo.Update(s.ctx, instance.ID, instance)
+	updateInstance := &models.Instance{
+		PublicIP: "192.0.2.100",
+		Status:   models.InstanceStatusReady,
+	}
+	err := s.instanceRepo.UpdateByID(s.ctx, instance.ID, updateInstance)
 	s.NoError(err)
 
 	// Verify update
@@ -85,40 +87,46 @@ func (s *InstanceRepositoryTestSuite) TestUpdate() {
 	s.NoError(err)
 	s.Equal("192.0.2.100", updated.PublicIP)
 	s.Equal(models.InstanceStatusReady, updated.Status)
-}
 
-func (s *InstanceRepositoryTestSuite) TestUpdateIPByName() {
-	instance := s.createTestInstance()
-	newIP := "192.0.2.200"
-
-	err := s.instanceRepo.UpdateIPByName(s.ctx, instance.Name, newIP)
+	// Test updating IP
+	updateIP := &models.Instance{
+		PublicIP: "192.0.2.200",
+	}
+	err = s.instanceRepo.UpdateByName(s.ctx, instance.Name, updateIP)
 	s.NoError(err)
 
-	updated, err := s.instanceRepo.GetByID(s.ctx, instance.JobID, instance.ID)
+	// Verify IP update
+	updated, err = s.instanceRepo.GetByID(s.ctx, instance.JobID, instance.ID)
 	s.NoError(err)
-	s.Equal(newIP, updated.PublicIP)
-}
+	s.Equal("192.0.2.200", updated.PublicIP)
 
-func (s *InstanceRepositoryTestSuite) TestUpdateStatus() {
-	instance := s.createTestInstance()
-
-	err := s.instanceRepo.UpdateStatus(s.ctx, instance.ID, models.InstanceStatusReady)
-	s.NoError(err)
-
-	updated, err := s.instanceRepo.GetByID(s.ctx, instance.JobID, instance.ID)
-	s.NoError(err)
-	s.Equal(models.InstanceStatusReady, updated.Status)
-}
-
-func (s *InstanceRepositoryTestSuite) TestUpdateStatusByName() {
-	instance := s.createTestInstance()
-
-	err := s.instanceRepo.UpdateStatusByName(s.ctx, instance.Name, models.InstanceStatusReady)
+	// Test updating status
+	updateStatus := &models.Instance{
+		Status: models.InstanceStatusReady,
+	}
+	err = s.instanceRepo.UpdateByName(s.ctx, instance.Name, updateStatus)
 	s.NoError(err)
 
-	updated, err := s.instanceRepo.GetByID(s.ctx, instance.JobID, instance.ID)
+	// Verify status update
+	updated, err = s.instanceRepo.GetByID(s.ctx, instance.JobID, instance.ID)
 	s.NoError(err)
 	s.Equal(models.InstanceStatusReady, updated.Status)
+
+	// Test updating multiple fields at once
+	updateMultiple := &models.Instance{
+		PublicIP: "192.0.2.300",
+		Status:   models.InstanceStatusProvisioning,
+		Region:   "sfo3",
+	}
+	err = s.instanceRepo.UpdateByName(s.ctx, instance.Name, updateMultiple)
+	s.NoError(err)
+
+	// Verify multiple updates
+	updated, err = s.instanceRepo.GetByID(s.ctx, instance.JobID, instance.ID)
+	s.NoError(err)
+	s.Equal("192.0.2.300", updated.PublicIP)
+	s.Equal(models.InstanceStatusProvisioning, updated.Status)
+	s.Equal("sfo3", updated.Region)
 }
 
 func (s *InstanceRepositoryTestSuite) TestList() {

--- a/internal/db/repos/instance_test.go
+++ b/internal/db/repos/instance_test.go
@@ -245,7 +245,7 @@ func (s *InstanceRepositoryTestSuite) TestApplyListOptions() {
 		{
 			name: "with status equal filter",
 			opts: &models.ListOptions{
-				Status: func() *models.InstanceStatus {
+				InstanceStatus: func() *models.InstanceStatus {
 					s := models.InstanceStatusReady
 					return &s
 				}(),
@@ -262,7 +262,7 @@ func (s *InstanceRepositoryTestSuite) TestApplyListOptions() {
 		{
 			name: "with status not equal filter",
 			opts: &models.ListOptions{
-				Status: func() *models.InstanceStatus {
+				InstanceStatus: func() *models.InstanceStatus {
 					s := models.InstanceStatusTerminated
 					return &s
 				}(),
@@ -309,7 +309,7 @@ func (s *InstanceRepositoryTestSuite) TestApplyListOptions() {
 				Limit:          10,
 				Offset:         20,
 				IncludeDeleted: true,
-				Status: func() *models.InstanceStatus {
+				InstanceStatus: func() *models.InstanceStatus {
 					s := models.InstanceStatusReady
 					return &s
 				}(),

--- a/test/api/v1/client_test.go
+++ b/test/api/v1/client_test.go
@@ -176,7 +176,7 @@ func TestClientInstanceMethods(t *testing.T) {
 		terminatedStatus := models.InstanceStatusTerminated
 		instanceList, err := suite.APIClient.GetInstances(suite.Context(), &models.ListOptions{
 			IncludeDeleted: true,
-			Status:         &terminatedStatus,
+			InstanceStatus: &terminatedStatus,
 		})
 		if err != nil {
 			return err

--- a/test/api/v1/client_test.go
+++ b/test/api/v1/client_test.go
@@ -119,11 +119,11 @@ func TestClientInstanceMethods(t *testing.T) {
 	err = suite.APIClient.CreateJob(suite.Context(), jobRequest)
 	require.NoError(t, err)
 
-	// Create an instance
+	// Create 2 instances
 	err = suite.APIClient.CreateInstance(suite.Context(), defaultInstancesRequest)
 	require.NoError(t, err)
 
-	// Wait for the instance to be available
+	// Wait for the instances to be available
 	err = suite.Retry(func() error {
 		instanceList, err := suite.APIClient.GetInstances(suite.Context(), &models.ListOptions{IncludeDeleted: true})
 		if err != nil {
@@ -165,7 +165,7 @@ func TestClientInstanceMethods(t *testing.T) {
 	// Delete both instances
 	deleteRequest := infrastructure.DeleteInstanceRequest{
 		JobName:       jobRequest.Name,
-		InstanceNames: []string{actualInstances[1].Name, actualInstances[0].Name},
+		InstanceNames: []string{actualInstances[0].Name, actualInstances[1].Name},
 	}
 	err = suite.APIClient.DeleteInstance(suite.Context(), deleteRequest)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

Tried to pick back up #100 and realized the `ListOptions` were instance opinionated and needs to be able to handle jobs as well. 

Due to the failing CI, this PR also improves some instance DB methods by making them into a single transaction to prevent race conditions.  Additionally this PR adds retry logic to the async service delete request to handle DB errors. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced filtering options for instance queries by adding distinct parameters for instance and job statuses.

- **Refactor**
  - Standardized naming conventions for filtering fields to improve consistency and clarity across the application.
  - Consolidated instance update operations to streamline database interactions.
  - Enhanced instance deletion process with improved error handling and management.

- **Tests**
  - Updated and expanded test scenarios with clearer naming and improved error messaging to ensure robust validation of the new filtering capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->