### PR TITLE
fix: reoder to load the .env correctly

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"strconv"
 
@@ -18,16 +19,18 @@ import (
 )
 
 func main() {
-	// Configure logger
+	// Load .env file first
+	if err := godotenv.Load(); err != nil {
+		// Use fmt.Printf here since logger isn't initialized yet
+		fmt.Printf("Error loading .env file: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Configure logger after loading .env
 	log.InitializeAndConfigure()
 
 	// Log that the application is starting
 	log.Info("Starting application...")
-
-	// Load .env file
-	if err := godotenv.Load(); err != nil {
-		log.Fatal("Error loading .env file")
-	}
 
 	// This is temporary, we will pass them through the CLI later
 	dbPort, err := strconv.Atoi(os.Getenv("DB_PORT"))


### PR DESCRIPTION
small one, found that the `.env` wasn't loading correctly to pass the values to the logger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Revised the application startup sequence to load configuration settings earlier, ensuring that any configuration errors are promptly and clearly reported during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->