### PR TITLE
fix: resolve nil apiClient error by unifying root commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ build-cli:
 ## run-cli: Run the Talis CLI tool
 run-cli:
 	@echo "Running Talis CLI..."
-	@./bin/talis-cli $(ARGS)
+	@go run ./cmd/cli/main.go $(ARGS)
 .PHONY: run-cli
 
 ## db-connect: Connect to the database

--- a/cmd/cli/commands/infrastructure.go
+++ b/cmd/cli/commands/infrastructure.go
@@ -13,7 +13,6 @@ import (
 )
 
 func init() {
-	RootCmd.AddCommand(infraCmd)
 	infraCmd.AddCommand(createInfraCmd)
 	infraCmd.AddCommand(deleteInfraCmd)
 

--- a/cmd/cli/commands/jobs.go
+++ b/cmd/cli/commands/jobs.go
@@ -23,7 +23,6 @@ type jobListOutput struct {
 }
 
 func init() {
-	RootCmd.AddCommand(jobsCmd)
 	jobsCmd.AddCommand(listJobsCmd)
 	jobsCmd.AddCommand(getJobCmd)
 

--- a/cmd/cli/commands/root.go
+++ b/cmd/cli/commands/root.go
@@ -21,10 +21,18 @@ func initClient() error {
 	return nil
 }
 
+func init() {
+	RootCmd.AddCommand(GetInfraCmd())
+	RootCmd.AddCommand(GetJobsCmd())
+	RootCmd.AddCommand(GetUsersCmd())
+}
+
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "talis",
-	Short: "Talis CLI tool",
+	Short: "Talis CLI - A command line interface for Talis API",
+	Long: `Talis CLI is a command line tool for managing infrastructure and jobs through the Talis API.
+	Complete documentation is available at https://github.com/celestiaorg/talis`,
 	PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 		return initClient()
 	},

--- a/cmd/cli/commands/root.go
+++ b/cmd/cli/commands/root.go
@@ -24,7 +24,6 @@ func initClient() error {
 func init() {
 	RootCmd.AddCommand(GetInfraCmd())
 	RootCmd.AddCommand(GetJobsCmd())
-	RootCmd.AddCommand(GetUsersCmd())
 }
 
 // RootCmd represents the base command when called without any subcommands

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -5,26 +5,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
-
 	"github.com/celestiaorg/talis/cmd/cli/commands"
 )
 
-var rootCmd = &cobra.Command{
-	Use:   "talis",
-	Short: "Talis CLI - A command line interface for Talis API",
-	Long: `Talis CLI is a command line tool for managing infrastructure and jobs through the Talis API.
-Complete documentation is available at https://github.com/celestiaorg/talis`,
-}
-
-func init() {
-	// Add all subcommands to root command
-	rootCmd.AddCommand(commands.GetInfraCmd())
-	rootCmd.AddCommand(commands.GetJobsCmd())
-}
-
 func main() {
-	if err := rootCmd.Execute(); err != nil {
+	if err := commands.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
# PR: Fix API Client Nil Pointer Error in CLI

## Background
The CLI application was experiencing runtime crashes with a nil pointer dereference when accessing the API client. This occurred because we had two separate root command implementations that weren't properly connected, causing commands initialized in one hierarchy to execute without proper client initialization.

## Issue
Commands attached to `commands.RootCmd` expected an initialized `apiClient`, but when executed through `main.go`'s separate `rootCmd`, it appears the initialization in `PersistentPreRunE` never ran, resulting in a nil pointer error.

## Solution
This PR unifies the command hierarchy by:
1. Removing the duplicate root command in `main.go`
2. Using the exported `RootCmd` and `Execute()` function from the commands package
3. Ensuring all commands run through the same initialization path that sets up the API client

This fix maintains the current command structure while ensuring consistent initialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added new CLI subcommands for managing infrastructure and jobs.
- **Documentation**
	- Enhanced command descriptions with clearer, more detailed overviews and a link to the documentation.
- **Refactor**
	- Streamlined the command execution process for a more efficient CLI experience.
- **Bug Fixes**
	- Removed accessibility of `infraCmd` and `jobsCmd` as subcommands of the root command, improving command hierarchy clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->