### PR TITLE
fix: add provider validation before provisioning instances

### DIFF
--- a/internal/compute/provider.go
+++ b/internal/compute/provider.go
@@ -54,6 +54,7 @@ func NewComputeProvider(provider models.ProviderID) (Provider, error) {
 	}
 }
 
+// IsValidProvider checks whether the given provider ID is supported.
 func IsValidProvider(provider models.ProviderID) bool {
 	if _, ok := validProviders[provider]; !ok {
 		return false

--- a/internal/compute/provider.go
+++ b/internal/compute/provider.go
@@ -54,18 +54,6 @@ func NewComputeProvider(provider models.ProviderID) (Provider, error) {
 	}
 }
 
-// IsValidProvider checks whether the given provider ID is supported.
-func IsValidProvider(provider models.ProviderID) bool {
-	if _, ok := validProviders[provider]; !ok {
-		return false
-	}
-	return true
-}
-
-var validProviders = map[models.ProviderID]struct{}{
-	"do-mock": {}, "digitalocean-mock": {}, "do": {},
-}
-
 // NewProvisioner creates a new system provisioner
 func NewProvisioner(jobID string) Provisioner {
 	return NewAnsibleConfigurator(jobID)

--- a/internal/compute/provider.go
+++ b/internal/compute/provider.go
@@ -54,6 +54,17 @@ func NewComputeProvider(provider models.ProviderID) (Provider, error) {
 	}
 }
 
+func IsValidProvider(provider models.ProviderID) bool {
+	if _, ok := validProviders[provider]; !ok {
+		return false
+	}
+	return true
+}
+
+var validProviders = map[models.ProviderID]struct{}{
+	"do-mock": {}, "digitalocean-mock": {}, "do": {},
+}
+
 // NewProvisioner creates a new system provisioner
 func NewProvisioner(jobID string) Provisioner {
 	return NewAnsibleConfigurator(jobID)

--- a/internal/db/models/provider.go
+++ b/internal/db/models/provider.go
@@ -25,6 +25,14 @@ const (
 	ProviderHetzner ProviderID = "hetzner"
 	// ProviderOVH represents OVH provider
 	ProviderOVH ProviderID = "ovh"
+
+	// Mock Providers
+	// ProviderDOMock1 represents DigitalOcean provider mock 1
+	ProviderDOMock1 ProviderID = "do-mock"
+	// ProviderDOMock2 represents DigitalOcean provider mock 2
+	ProviderDOMock2 ProviderID = "digitalocean-mock"
+	// ProviderDOMock3 represents a mock provider
+	ProviderMock3 ProviderID = "mock"
 )
 
 // String implements the fmt.Stringer interface
@@ -63,6 +71,8 @@ func (p ProviderID) IsValid() bool {
 	switch p {
 	case ProviderAWS, ProviderGCP, ProviderAzure, ProviderDO,
 		ProviderScaleway, ProviderVultr, ProviderLinode, ProviderHetzner, ProviderOVH:
+		return true
+	case ProviderDOMock1, ProviderDOMock2, ProviderMock3: // mocked providers
 		return true
 	default:
 		return false

--- a/internal/services/instance.go
+++ b/internal/services/instance.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/celestiaorg/talis/internal/compute"
 	"github.com/celestiaorg/talis/internal/db/models"
 	"github.com/celestiaorg/talis/internal/db/repos"
 	"github.com/celestiaorg/talis/internal/logger"
@@ -50,12 +49,6 @@ func (s *Instance) CreateInstance(ctx context.Context, ownerID uint, projectName
 		return "", fmt.Errorf("at least one instance is required")
 	}
 
-	// validate the providers
-	for _, instance := range instances {
-		if !compute.IsValidProvider(instance.Provider) {
-			return "", fmt.Errorf("unsupported provider: %s", instance.Provider)
-		}
-	}
 	// Generate TaskName internally
 	taskName := uuid.New().String()
 	err = s.taskService.Create(ctx, &models.Task{

--- a/internal/services/instance.go
+++ b/internal/services/instance.go
@@ -45,9 +45,16 @@ func (s *Instance) CreateInstance(ctx context.Context, ownerID uint, projectName
 		return "", fmt.Errorf("failed to get project: %w", err)
 	}
 
-	// validate the provider
-	if !compute.IsValidProvider(instances[0].Provider) {
-		return "", fmt.Errorf("unsupported provider: %s", instances[0].Provider)
+	// validate the instances array is not empty
+	if len(instances) == 0 {
+		return "", fmt.Errorf("at least one instance is required")
+	}
+
+	// validate the providers
+	for _, instance := range instances {
+		if !compute.IsValidProvider(instance.Provider) {
+			return "", fmt.Errorf("unsupported provider: %s", instance.Provider)
+		}
 	}
 	// Generate TaskName internally
 	taskName := uuid.New().String()

--- a/internal/services/instance.go
+++ b/internal/services/instance.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/celestiaorg/talis/internal/compute"
 	"github.com/celestiaorg/talis/internal/db/models"
 	"github.com/celestiaorg/talis/internal/db/repos"
 	"github.com/celestiaorg/talis/internal/logger"
@@ -44,6 +45,10 @@ func (s *Instance) CreateInstance(ctx context.Context, ownerID uint, projectName
 		return "", fmt.Errorf("failed to get project: %w", err)
 	}
 
+	// validate the provider
+	if !compute.IsValidProvider(instances[0].Provider) {
+		return "", fmt.Errorf("unsupported provider: %s", instances[0].Provider)
+	}
 	// Generate TaskName internally
 	taskName := uuid.New().String()
 	err = s.taskService.Create(ctx, ownerID, project.ID, &models.Task{

--- a/internal/types/instance.go
+++ b/internal/types/instance.go
@@ -121,6 +121,9 @@ func (i *InstanceRequest) Validate() error {
 	if i.Provider == "" {
 		return fmt.Errorf("provider is required")
 	}
+	if !i.Provider.IsValid() {
+		return fmt.Errorf("unsupported provider: %s", i.Provider)
+	}
 	if i.NumberOfInstances < 1 {
 		return fmt.Errorf("number_of_instances must be greater than 0")
 	}


### PR DESCRIPTION
### **Add provider validation to prevent unsupported infrastructure provisioning**  


### **Context & Background:**  
Previously, infrastructure provisioning would fail **asynchronously** during the creation phase if an unsupported provider (e.g., `"digitalocean"`) was specified in the request. This resulted in a misleading initial CLI response (`"Infrastructure creation request submitted successfully"`) followed by an error logged only on the server side.  

The core issue was that provider validation was deferred until the provisioning goroutine, rather than being handled upfront.

---

### **Goal:**  
Ensure that invalid or unsupported provider values are caught **early**, during the `CreateInstance` call, to provide immediate feedback and prevent unnecessary task creation or async failures.

---

### **Changes Made:**
- Added `IsValidProvider` helper in the `compute` package.
- Performed validation on the provider ID at the start of `CreateInstance`, before instance or task creation begins.

---

### **Rationale:**  
By validating providers early:
- We fail fast and provide clearer error messages to users.
- We avoid launching background provisioning jobs that are doomed to fail.
- It improves overall system robustness and developer/operator experience.

Closes: #201 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for new mock providers, which are now recognized as valid options.
- **Bug Fixes**
  - Improved validation to ensure at least one instance is provided when creating instances.
  - Enhanced provider validation to reject unsupported provider values during instance requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->