### PR TITLE
fix: Improve Robustness and Refactor Instance Service

### DIFF
--- a/internal/services/instance.go
+++ b/internal/services/instance.go
@@ -387,7 +387,7 @@ func (s *Instance) provisionInstances(
 
 	// --- Optional Ansible Provisioning ---
 	if !anyUpdateFailed && len(instancesReq) > 0 && instancesReq[0].Provision {
-		s.runAnsibleProvisioning(ctx, task, *infra, pInstances, instanceNameToOwnerID)
+		s.runAnsibleProvisioning(ctx, task, infra, pInstances, instanceNameToOwnerID)
 	} else if anyUpdateFailed {
 		logger.Warnf("Skipping Ansible provisioning for task %d due to previous update errors.", taskID)
 		s.addTaskLogs(ctx, callerOwnerID, task, "Skipping Ansible provisioning due to previous errors.")
@@ -406,7 +406,7 @@ func (s *Instance) provisionInstances(
 func (s *Instance) runAnsibleProvisioning(
 	ctx context.Context,
 	task *models.Task,
-	infra Infrastructure,
+	infra *Infrastructure,
 	pInstances []types.InstanceInfo,
 	instanceNameToOwnerID map[string]uint,
 ) {


### PR DESCRIPTION
## Description

This PR addresses several issues related to instance creation and termination within the `InstanceService`, significantly improving its robustness, error handling, and maintainability. The main problems were related to incorrect `OwnerID` management, ambiguous identification of instances with duplicate names (especially across different tasks or projects), 
and inflexible handling of partial failures during termination.

example error record:
```
11	2025-04-22 11:00:54.277 +0200	2025-04-22 11:00:54.277 +0200		4294967295	2	46	do	test		nyc3	s-1vcpu-1gb		{talis,dev,testing}	4	{}	[]	0
```

Additionally, the code has been refactored to extract complex logic into helper functions, and linter warnings have been corrected.

## Key Changes

*   **Volume Update Fix:**
    *   Corrected `updateInstanceVolumes` to use the correct `OwnerID` of the instance when fetching and updating it, instead of using an admin ID or the caller's ID from the main task.
    *   Prevented volume data overwrite during the IP/status update in `provisionInstances` by re-fetching the latest instance state after the volume update and before the final update.
*   **Correct Identification in `provisionInstances`:**
    *   Introduced robust logic (helper `findPendingInstanceForTask`) to identify the specific instance in `Pending` state associated with the current `taskID`, even if other instances (active or terminated) with the same name exist.
    *   Implemented a fallback mechanism using `List` if `GetByName` returns an incorrect instance or fails.
    *   Ensured the correct instance-specific `OwnerID` (obtained from the `instanceNameToOwnerID` map) is used for all database operations within the goroutine.
*   **Improved Handling in `Terminate`:**
    *   Refactored `Terminate` to correctly handle requests that include invalid, non-existent, or already terminated instance names without failing the entire operation.
    *   Removed reliance on `GetByProjectIDAndInstanceNames`. Now lists instances for the project owner (`project.OwnerID`) and filters programmatically (helper `findActiveInstancesForTermination`) to find valid instances matching both the requested `name` **and** `project.ID` that are not already terminated.
    *   Skipped instances are clearly logged in the task logs with the specific reason (e.g., "not found in project", "already terminated").
*   **Fast Response in `Terminate` API:**
    *   The `Terminate` function now creates the task (`Pending`) and returns the `taskName` immediately.
    *   The main logic (identifying instances, logging skipped ones, initiating the actual termination) has been moved to a background goroutine (`handleTerminationInBackground`) to avoid blocking the API response.
*   **Correct `OwnerID` in `terminate` Goroutine:** Ensured the call to `s.repo.Terminate` within the deletion goroutine uses the correct `OwnerID` of the instance being deleted.
*   **Linter Warning Fixes:** Modified multiple calls to `logger.Xf` and `fmt.Errorf` to use constant format strings as the first argument, passing variables as subsequent arguments.
*   **Refactoring and Readability:**
    *   Extracted complex instance identification logic in `provisionInstances` and `Terminate` into helper functions (`findPendingInstanceForTask`, `findInstanceForTask`, `findActiveInstancesForTermination`).
    *   Extracted Ansible logic into `runAnsibleProvisioning`.
    *   Improved error handling and logging in various parts.
    *   Simplified the flow in the main functions.

## How to Test

1.  Create an instance with volumes. Verify that volumes are saved correctly in the DB.
2.  Create instance "test-dup". Terminate it. Create "test-dup" again. Verify the new instance is provisioned and updated correctly (IP, volumes).
3.  Create instances A, B, C in "project-X". Attempt to terminate ["A", "D", "B"] from "project-X". Verify that A and B are terminated, D is logged as skipped ("not found in project"), and the API returns success.
4.  Attempt to terminate instance A from "project-Y". Verify it's logged as skipped ("wrong project") and not deleted.
5.  Verify that the `/terminate` API call responds quickly with a `taskName`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved tracking and visibility of instance creation and termination tasks, including more detailed status updates and logging.
	- Added background processing for instance termination to enhance responsiveness.
	- Introduced enhanced instance identification and volume update mechanisms during provisioning.
	- Added automated provisioning steps with improved error handling and retry logic.
- **Bug Fixes**
	- Enhanced error handling and reporting for instance provisioning and termination processes to prevent stale or missing updates.
- **Refactor**
	- Streamlined asynchronous processing for instance operations, resulting in more reliable and robust workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->