### PR TITLE
feat: introduce DBBatchSize constant for batch operations

### DIFF
--- a/internal/db/models/models.go
+++ b/internal/db/models/models.go
@@ -3,6 +3,8 @@ package models
 const (
 	// DefaultLimit is the max number of rows that are retrieved from the DB per listing API call
 	DefaultLimit = 50
+	// DBBatchSize is the standard batch size for DB CreateBatch operations
+	DBBatchSize = 100
 )
 
 // StatusFilter represents how to filter db items by status

--- a/internal/db/repos/instance.go
+++ b/internal/db/repos/instance.go
@@ -327,6 +327,6 @@ func (r *InstanceRepository) CreateBatch(ctx context.Context, instances []*model
 		}
 	}
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		return tx.CreateInBatches(instances, 100).Error
+		return tx.CreateInBatches(instances, models.DBBatchSize).Error
 	})
 }

--- a/internal/db/repos/project.go
+++ b/internal/db/repos/project.go
@@ -30,7 +30,7 @@ func (r *ProjectRepository) Create(ctx context.Context, project *models.Project)
 // CreateBatch creates a batch of projects in the database
 func (r *ProjectRepository) CreateBatch(ctx context.Context, projects []*models.Project) error {
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		return tx.CreateInBatches(projects, 100).Error
+		return tx.CreateInBatches(projects, models.DBBatchSize).Error
 	})
 }
 

--- a/internal/db/repos/task.go
+++ b/internal/db/repos/task.go
@@ -31,7 +31,7 @@ func (r *TaskRepository) Create(ctx context.Context, task *models.Task) error {
 // CreateBatch creates a batch of tasks in the database
 func (r *TaskRepository) CreateBatch(ctx context.Context, tasks []*models.Task) error {
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		return tx.CreateInBatches(tasks, 100).Error
+		return tx.CreateInBatches(tasks, models.DBBatchSize).Error
 	})
 }
 

--- a/internal/db/repos/user.go
+++ b/internal/db/repos/user.go
@@ -37,7 +37,7 @@ func (r *UserRepository) CreateUser(ctx context.Context, user *models.User) erro
 // CreateBatch creates a batch of users in the database
 func (r *UserRepository) CreateBatch(ctx context.Context, users []*models.User) error {
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		return tx.CreateInBatches(users, 100).Error
+		return tx.CreateInBatches(users, models.DBBatchSize).Error
 	})
 }
 


### PR DESCRIPTION
This PR extracts the hardcoded database batch size _**(100)**_ used in various **CreateBatch** and **CreateInBatches** operations into a shared constant: **_models.DBBatchSize_**. This change standardizes the batch size across the codebase, making it easier to update and maintain in the future. The constant is now used in all relevant repository methods for batch creation of users, projects, tasks, and instances.

**Context & Rationale:**

- Previously, the batch size was duplicated as a magic number in multiple places.
- Centralizing this value improves maintainability and reduces the risk of inconsistencies.
- This is a preparatory refactor for future scalability and configuration improvements.

No functional changes are introduced; this is a refactor for code quality and maintainability.

Closes #233 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized the batch size for database batch create operations across multiple repositories by using a single configurable constant. This ensures consistent batch processing behavior throughout the application. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->