### PR TITLE
feat: return task names on successful instance creation

### DIFF
--- a/internal/types/responses.go
+++ b/internal/types/responses.go
@@ -35,3 +35,8 @@ type ListResponse[T any] struct {
 	Rows       []T                `json:"rows"`
 	Pagination PaginationResponse `json:"pagination"`
 }
+
+// ResponseWithTaskNames defines the structure for a successful response with task names
+type ResponseWithTaskNames struct {
+	TaskNames []string `json:"task_names"`
+}

--- a/pkg/api/v1/handlers/instance.go
+++ b/pkg/api/v1/handlers/instance.go
@@ -112,14 +112,17 @@ func (h *InstanceHandler) CreateInstance(c *fiber.Ctx) error {
 		}
 	}
 
-	err := h.service.CreateInstance(c.Context(), instanceReqs)
+	taskNames, err := h.service.CreateInstance(c.Context(), instanceReqs)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).
 			JSON(types.ErrServer(err.Error()))
 	}
 
 	return c.Status(fiber.StatusCreated).
-		JSON(types.Success(nil))
+		JSON(types.Success(
+			types.ResponseWithTaskNames{
+				TaskNames: taskNames,
+			}))
 }
 
 // GetPublicIPs returns a list of public IPs for all instances


### PR DESCRIPTION
This PR adds the task-names to the instance creation response for easier tracking of the tasks.