### PR TITLE
feat: create common APIHandler to refactor service creation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -70,13 +70,17 @@ func main() {
 	userService := services.NewUserService(userRepo)
 
 	// Initialize handlers
-	instanceHandler := handlers.NewInstanceHandler(instanceService)
+	apiHandler := handlers.NewAPIHandler(instanceService, projectService, taskService, userService)
+	instanceHandler := handlers.NewInstanceHandler(apiHandler)
+	projectHandler := handlers.NewProjectHandlers(apiHandler)
+	taskHandler := handlers.NewTaskHandlers(apiHandler)
+	userHandler := handlers.NewUserHandler(apiHandler)
 
 	// Create RPC handler and assign handlers directly
 	rpcHandler := &handlers.RPCHandler{
-		ProjectHandlers: handlers.NewProjectHandlers(projectService),
-		TaskHandlers:    handlers.NewTaskHandlers(taskService),
-		UserHandlers:    handlers.NewUserHandler(userService),
+		ProjectHandlers: projectHandler,
+		TaskHandlers:    taskHandler,
+		UserHandlers:    userHandler,
 	}
 
 	// Setup Fiber app

--- a/pkg/api/v1/handlers/api.go
+++ b/pkg/api/v1/handlers/api.go
@@ -1,0 +1,21 @@
+package handlers
+
+import "github.com/celestiaorg/talis/internal/services"
+
+// APIHandler is a handler for the API
+type APIHandler struct {
+	instance *services.Instance
+	project  *services.Project
+	task     *services.Task
+	user     *services.User
+}
+
+// NewAPIHandler creates a new API handler
+func NewAPIHandler(instance *services.Instance, project *services.Project, task *services.Task, user *services.User) *APIHandler {
+	return &APIHandler{
+		instance: instance,
+		project:  project,
+		task:     task,
+		user:     user,
+	}
+}

--- a/pkg/api/v1/handlers/instance.go
+++ b/pkg/api/v1/handlers/instance.go
@@ -7,19 +7,18 @@ import (
 	fiber "github.com/gofiber/fiber/v2"
 
 	"github.com/celestiaorg/talis/internal/db/models"
-	"github.com/celestiaorg/talis/internal/services"
 	"github.com/celestiaorg/talis/internal/types"
 )
 
 // InstanceHandler handles HTTP requests for instance operations
 type InstanceHandler struct {
-	service *services.Instance
+	*APIHandler
 }
 
 // NewInstanceHandler creates a new instance handler instance
-func NewInstanceHandler(service *services.Instance) *InstanceHandler {
+func NewInstanceHandler(api *APIHandler) *InstanceHandler {
 	return &InstanceHandler{
-		service: service,
+		APIHandler: api,
 	}
 }
 
@@ -47,7 +46,7 @@ func (h *InstanceHandler) ListInstances(c *fiber.Ctx) error {
 
 	// TODO: should check for OwnerID and filter by it
 
-	instances, err := h.service.ListInstances(c.Context(), models.AdminID, &opts)
+	instances, err := h.instance.ListInstances(c.Context(), models.AdminID, &opts)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": fmt.Sprintf("failed to list instances: %v", err),
@@ -79,7 +78,7 @@ func (h *InstanceHandler) GetInstance(c *fiber.Ctx) error {
 	}
 
 	// Get instance using the service
-	instance, err := h.service.GetInstance(c.Context(), models.AdminID, uint(instanceID))
+	instance, err := h.instance.GetInstance(c.Context(), models.AdminID, uint(instanceID))
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": fmt.Sprintf("failed to get instance: %v", err),
@@ -112,7 +111,7 @@ func (h *InstanceHandler) CreateInstance(c *fiber.Ctx) error {
 		}
 	}
 
-	err := h.service.CreateInstance(c.Context(), instanceReqs)
+	err := h.instance.CreateInstance(c.Context(), instanceReqs)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).
 			JSON(types.ErrServer(err.Error()))
@@ -139,7 +138,7 @@ func (h *InstanceHandler) GetPublicIPs(c *fiber.Ctx) error {
 	}
 
 	// Get instances with their details using the service
-	instances, err := h.service.ListInstances(c.Context(), models.AdminID, &opts)
+	instances, err := h.instance.ListInstances(c.Context(), models.AdminID, &opts)
 	if err != nil {
 		fmt.Printf("❌ Error getting public IPs: %v\n", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
@@ -186,7 +185,7 @@ func (h *InstanceHandler) GetAllMetadata(c *fiber.Ctx) error {
 	}
 
 	// Get instances with their details using the service
-	instances, err := h.service.ListInstances(c.Context(), models.AdminID, &opts)
+	instances, err := h.instance.ListInstances(c.Context(), models.AdminID, &opts)
 	if err != nil {
 		fmt.Printf("❌ Error getting instance: %v\n", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
@@ -226,7 +225,7 @@ func (h *InstanceHandler) GetInstances(c *fiber.Ctx) error {
 		opts.InstanceStatus = &status
 	}
 
-	instances, err := h.service.ListInstances(c.Context(), models.AdminID, &opts)
+	instances, err := h.instance.ListInstances(c.Context(), models.AdminID, &opts)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": fmt.Sprintf("failed to list instances: %v", err),
@@ -258,7 +257,7 @@ func (h *InstanceHandler) TerminateInstances(c *fiber.Ctx) error {
 		})
 	}
 
-	err := h.service.Terminate(c.Context(), deleteReq.OwnerID, deleteReq.ProjectName, deleteReq.InstanceNames)
+	err := h.instance.Terminate(c.Context(), deleteReq.OwnerID, deleteReq.ProjectName, deleteReq.InstanceNames)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": fmt.Sprintf("failed to terminate instances: %v", err),

--- a/pkg/api/v1/handlers/project.go
+++ b/pkg/api/v1/handlers/project.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 
 	"github.com/celestiaorg/talis/internal/db/models"
-	"github.com/celestiaorg/talis/internal/services"
 	"github.com/celestiaorg/talis/internal/types"
 	"gorm.io/gorm"
 
@@ -14,13 +13,13 @@ import (
 
 // ProjectHandlers contains all project related handlers
 type ProjectHandlers struct {
-	service *services.Project
+	*APIHandler
 }
 
 // NewProjectHandlers creates a new project handlers instance
-func NewProjectHandlers(projectService *services.Project) *ProjectHandlers {
+func NewProjectHandlers(api *APIHandler) *ProjectHandlers {
 	return &ProjectHandlers{
-		service: projectService,
+		APIHandler: api,
 	}
 }
 
@@ -42,7 +41,7 @@ func (h *ProjectHandlers) Create(c *fiber.Ctx, req RPCRequest) error {
 		Config:      params.Config,
 	}
 
-	if err := h.service.Create(c.Context(), &project); err != nil {
+	if err := h.project.Create(c.Context(), &project); err != nil {
 		return respondWithRPCError(c, fiber.StatusInternalServerError, ErrMsgProjCreateFailed, err.Error(), req.ID)
 	}
 
@@ -64,7 +63,7 @@ func (h *ProjectHandlers) Get(c *fiber.Ctx, req RPCRequest) error {
 		return respondWithRPCError(c, fiber.StatusBadRequest, err.Error(), nil, req.ID)
 	}
 
-	project, err := h.service.GetByName(c.Context(), params.OwnerID, params.Name)
+	project, err := h.project.GetByName(c.Context(), params.OwnerID, params.Name)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return respondWithRPCError(c, fiber.StatusNotFound, ErrMsgProjNotFound, err.Error(), req.ID)
@@ -98,7 +97,7 @@ func (h *ProjectHandlers) List(c *fiber.Ctx, req RPCRequest) error {
 
 	listOpts := getPaginationOptions(page)
 
-	projects, err := h.service.List(c.Context(), params.OwnerID, listOpts)
+	projects, err := h.project.List(c.Context(), params.OwnerID, listOpts)
 	if err != nil {
 		return respondWithRPCError(c, fiber.StatusInternalServerError, ErrMsgProjListFailed, err.Error(), req.ID)
 	}
@@ -129,7 +128,7 @@ func (h *ProjectHandlers) Delete(c *fiber.Ctx, req RPCRequest) error {
 		return respondWithRPCError(c, fiber.StatusBadRequest, err.Error(), nil, req.ID)
 	}
 
-	if err := h.service.Delete(c.Context(), params.OwnerID, params.Name); err != nil {
+	if err := h.project.Delete(c.Context(), params.OwnerID, params.Name); err != nil {
 		return respondWithRPCError(c, fiber.StatusInternalServerError, ErrMsgProjDeleteFailed, err.Error(), req.ID)
 	}
 
@@ -151,7 +150,7 @@ func (h *ProjectHandlers) ListInstances(c *fiber.Ctx, req RPCRequest) error {
 	}
 
 	listOpts := getPaginationOptions(params.Page)
-	instances, err := h.service.ListInstances(c.Context(), params.OwnerID, params.Name, listOpts)
+	instances, err := h.project.ListInstances(c.Context(), params.OwnerID, params.Name, listOpts)
 	if err != nil {
 		return respondWithRPCError(c, fiber.StatusInternalServerError, "Failed to list project instances", err.Error(), req.ID)
 	}

--- a/pkg/api/v1/handlers/user.go
+++ b/pkg/api/v1/handlers/user.go
@@ -7,19 +7,18 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/celestiaorg/talis/internal/db/models"
-	"github.com/celestiaorg/talis/internal/services"
 	"github.com/celestiaorg/talis/internal/types"
 )
 
 // UserHandler handles HTTP requests for user operations
 type UserHandler struct {
-	service *services.User
+	*APIHandler
 }
 
 // NewUserHandler creates a new UserHandler instance
-func NewUserHandler(service *services.User) *UserHandler {
+func NewUserHandler(api *APIHandler) *UserHandler {
 	return &UserHandler{
-		service: service,
+		APIHandler: api,
 	}
 }
 
@@ -41,7 +40,7 @@ func (h *UserHandler) CreateUser(c *fiber.Ctx, req RPCRequest) error {
 		PublicSSHKey: params.PublicSSHKey,
 	}
 
-	id, err := h.service.CreateUser(c.Context(), user)
+	id, err := h.user.CreateUser(c.Context(), user)
 	if err != nil {
 		return respondWithRPCError(c, fiber.StatusInternalServerError, ErrMsgCreateUserFailed, err.Error(), req.ID)
 	}
@@ -66,7 +65,7 @@ func (h *UserHandler) GetUserByID(c *fiber.Ctx, req RPCRequest) error {
 		return respondWithRPCError(c, fiber.StatusBadRequest, err.Error(), nil, req.ID)
 	}
 
-	user, err := h.service.GetUserByID(c.Context(), params.ID)
+	user, err := h.user.GetUserByID(c.Context(), params.ID)
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return respondWithRPCError(c, fiber.StatusNotFound, ErrMsgUserNotFoundByID, nil, req.ID)
 	} else if err != nil {
@@ -102,7 +101,7 @@ func (h *UserHandler) GetUsers(c *fiber.Ctx, req RPCRequest) error {
 	}
 	paginationOpts := getPaginationOptions(page)
 
-	users, err := h.service.GetAllUsers(c.Context(), paginationOpts)
+	users, err := h.user.GetAllUsers(c.Context(), paginationOpts)
 	if err != nil {
 		return respondWithRPCError(c, fiber.StatusInternalServerError, ErrMsgGetUsersFailed, err.Error(), req.ID)
 	}
@@ -122,7 +121,7 @@ func (h *UserHandler) GetUsers(c *fiber.Ctx, req RPCRequest) error {
 
 // getUserByUsername handles fetching a single user by username
 func (h *UserHandler) getUserByUsername(c *fiber.Ctx, username string, req RPCRequest) error {
-	user, err := h.service.GetUserByUsername(c.Context(), username)
+	user, err := h.user.GetUserByUsername(c.Context(), username)
 
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return respondWithRPCError(c, fiber.StatusNotFound, ErrMsgUserNotFoundByUsername, nil, req.ID)
@@ -155,7 +154,7 @@ func (h *UserHandler) DeleteUser(c *fiber.Ctx, req RPCRequest) error {
 		return respondWithRPCError(c, fiber.StatusBadRequest, err.Error(), nil, req.ID)
 	}
 
-	err = h.service.DeleteUser(c.Context(), params.ID)
+	err = h.user.DeleteUser(c.Context(), params.ID)
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return respondWithRPCError(c, fiber.StatusNotFound, ErrMsgUserNotFoundByID, nil, req.ID)
 	}

--- a/test/server.go
+++ b/test/server.go
@@ -34,11 +34,15 @@ func SetupServer(suite *Suite) {
 	instanceService := services.NewInstanceService(suite.InstanceRepo, taskService, projectService)
 
 	// Create handlers
-	instanceHandler := handlers.NewInstanceHandler(instanceService)
+	apiHandler := handlers.NewAPIHandler(instanceService, projectService, taskService, userService)
+	instanceHandler := handlers.NewInstanceHandler(apiHandler)
+	projectHandler := handlers.NewProjectHandlers(apiHandler)
+	taskHandler := handlers.NewTaskHandlers(apiHandler)
+	userHandler := handlers.NewUserHandler(apiHandler)
 	rpcHandler := &handlers.RPCHandler{
-		ProjectHandlers: handlers.NewProjectHandlers(projectService),
-		TaskHandlers:    handlers.NewTaskHandlers(taskService),
-		UserHandlers:    handlers.NewUserHandler(userService),
+		ProjectHandlers: projectHandler,
+		TaskHandlers:    taskHandler,
+		UserHandlers:    userHandler,
 	}
 
 	// Register routes


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

As the API becomes more complex, API endpoints will need access to more services. To reduce the number of changes of adding new services to each handler, I created a single handler to be used under each.

This also helps clear things up about being explicit as to what service is being called when an API route interacts with multiple services. 

The reason I didn't completely remove the individual handlers is because currently the RPC references the methods of each handler, so `InstanceHandler.Get` could conflict with `UserHandler.Get` as an example if we were to implement the same method name. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Centralized API handler dependencies by introducing a shared handler structure for instance, project, task, and user operations.
  - Updated handler initialization to use the new shared handler, streamlining internal service management.
- **Chores**
  - Improved internal handler construction for better maintainability and consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->