### PR TITLE
feat: Make internal models and types public via aliases

### DIFF
--- a/cmd/cli/commands/infrastructure.go
+++ b/cmd/cli/commands/infrastructure.go
@@ -120,7 +120,7 @@ var deleteInfraCmd = &cobra.Command{
 		}
 
 		// Call the API client
-		err = apiClient.DeleteInstance(context.Background(), req)
+		err = apiClient.DeleteInstances(context.Background(), req)
 		if err != nil {
 			return fmt.Errorf("error deleting infrastructure: %w", err)
 		}

--- a/pkg/db/models/instance.go
+++ b/pkg/db/models/instance.go
@@ -1,0 +1,44 @@
+// Package models contains PUBLIC aliases for database models and related types.
+//
+// NOTE: This package uses type aliases to internal definitions
+// as a temporary measure. This should be revisited
+// during a proper refactoring to define stable public types.
+package models
+
+import (
+	internalmodels "github.com/celestiaorg/talis/internal/db/models"
+)
+
+// InstanceStatus represents the current state of an instance
+type InstanceStatus = internalmodels.InstanceStatus
+
+// Instance status constants
+const (
+	InstanceStatusUnknown      InstanceStatus = internalmodels.InstanceStatusUnknown
+	InstanceStatusPending      InstanceStatus = internalmodels.InstanceStatusPending
+	InstanceStatusCreated      InstanceStatus = internalmodels.InstanceStatusCreated
+	InstanceStatusProvisioning InstanceStatus = internalmodels.InstanceStatusProvisioning
+	InstanceStatusReady        InstanceStatus = internalmodels.InstanceStatusReady
+	InstanceStatusTerminated   InstanceStatus = internalmodels.InstanceStatusTerminated
+)
+
+// PayloadStatus represents the state of a payload operation on an instance
+type PayloadStatus = internalmodels.PayloadStatus
+
+// Payload status constants
+const (
+	PayloadStatusNone             PayloadStatus = internalmodels.PayloadStatusNone
+	PayloadStatusPendingCopy      PayloadStatus = internalmodels.PayloadStatusPendingCopy
+	PayloadStatusCopyFailed       PayloadStatus = internalmodels.PayloadStatusCopyFailed
+	PayloadStatusCopied           PayloadStatus = internalmodels.PayloadStatusCopied
+	PayloadStatusPendingExecution PayloadStatus = internalmodels.PayloadStatusPendingExecution
+	PayloadStatusExecutionFailed  PayloadStatus = internalmodels.PayloadStatusExecutionFailed
+	PayloadStatusExecuted         PayloadStatus = internalmodels.PayloadStatusExecuted
+)
+
+// Instance represents a compute instance in the system (public alias)
+type Instance = internalmodels.Instance
+
+// NOTE: Methods like String(), ParseInstanceStatus(), MarshalJSON(), UnmarshalJSON()
+// are defined on the original internal types and are used via the aliases.
+// DO NOT REDEFINE METHODS ON ALIAS TYPES HERE.

--- a/pkg/db/models/models.go
+++ b/pkg/db/models/models.go
@@ -1,0 +1,29 @@
+package models
+
+// NOTE: This package uses type aliases to internal definitions
+// as a temporary measure. This should be revisited
+// during a proper refactoring to define stable public types.
+
+import (
+	internalmodels "github.com/celestiaorg/talis/internal/db/models"
+)
+
+// StatusFilter represents how to filter db items by status
+type StatusFilter = internalmodels.StatusFilter
+
+const (
+	// StatusFilterEqual indicates filtering for instances with matching status
+	StatusFilterEqual StatusFilter = internalmodels.StatusFilterEqual
+	// StatusFilterNotEqual indicates filtering for instances with non-matching status
+	StatusFilterNotEqual StatusFilter = internalmodels.StatusFilterNotEqual
+)
+
+// ListOptions represents pagination and filtering options for list operations
+type ListOptions = internalmodels.ListOptions
+
+// NOTE: Constants like DefaultLimit are not aliased here,
+// as they are often specific to internal usage (like DB batching)
+// or defined contextually (like DefaultPageSize in handlers).
+
+// UserQueryOptions represents query params for GetUserByUsername operation
+type UserQueryOptions = internalmodels.UserQueryOptions

--- a/pkg/db/models/project.go
+++ b/pkg/db/models/project.go
@@ -1,0 +1,15 @@
+// Package models contains PUBLIC aliases for database models and related types.
+//
+// NOTE: This package uses type aliases to internal definitions
+// as a temporary measure. This should be revisited
+// during a proper refactoring to define stable public types.
+package models
+
+import (
+	internalmodels "github.com/celestiaorg/talis/internal/db/models"
+)
+
+// Project represents a project in the system (public alias).
+type Project = internalmodels.Project
+
+// NOTE: Methods are defined on the original internal types.

--- a/pkg/db/models/provider.go
+++ b/pkg/db/models/provider.go
@@ -1,0 +1,35 @@
+// Package models contains PUBLIC aliases for database models and related types.
+//
+// NOTE: This package uses type aliases to internal definitions
+// as a temporary measure. This should be revisited
+// during a proper refactoring to define stable public types.
+package models
+
+import (
+	internalmodels "github.com/celestiaorg/talis/internal/db/models"
+)
+
+// ProviderID represents a compute provider
+type ProviderID = internalmodels.ProviderID
+
+// Provider constants
+const (
+	ProviderAWS      ProviderID = internalmodels.ProviderAWS
+	ProviderGCP      ProviderID = internalmodels.ProviderGCP
+	ProviderAzure    ProviderID = internalmodels.ProviderAzure
+	ProviderDO       ProviderID = internalmodels.ProviderDO
+	ProviderScaleway ProviderID = internalmodels.ProviderScaleway
+	ProviderVultr    ProviderID = internalmodels.ProviderVultr
+	ProviderLinode   ProviderID = internalmodels.ProviderLinode
+	ProviderHetzner  ProviderID = internalmodels.ProviderHetzner
+	ProviderOVH      ProviderID = internalmodels.ProviderOVH
+
+	// Mock Providers
+	ProviderDOMock1 ProviderID = internalmodels.ProviderDOMock1
+	ProviderDOMock2 ProviderID = internalmodels.ProviderDOMock2
+	ProviderMock3   ProviderID = internalmodels.ProviderMock3
+)
+
+// NOTE: Methods like IsValid, MarshalJSON, UnmarshalJSON are defined on the
+// original internal types and are used via the aliases.
+// DO NOT REDEFINE METHODS ON ALIAS TYPES HERE.

--- a/pkg/db/models/task.go
+++ b/pkg/db/models/task.go
@@ -1,0 +1,44 @@
+// Package models contains PUBLIC aliases for database models and related types.
+//
+// NOTE: This package uses type aliases to internal definitions
+// as a temporary measure. This should be revisited
+// during a proper refactoring to define stable public types.
+package models
+
+import (
+	internalmodels "github.com/celestiaorg/talis/internal/db/models"
+)
+
+// TaskStatus represents the status of a task.
+type TaskStatus = internalmodels.TaskStatus
+
+// Task status constants.
+const (
+	TaskStatusUnknown    TaskStatus = internalmodels.TaskStatusUnknown
+	TaskStatusPending    TaskStatus = internalmodels.TaskStatusPending
+	TaskStatusRunning    TaskStatus = internalmodels.TaskStatusRunning
+	TaskStatusCompleted  TaskStatus = internalmodels.TaskStatusCompleted
+	TaskStatusFailed     TaskStatus = internalmodels.TaskStatusFailed
+	TaskStatusTerminated TaskStatus = internalmodels.TaskStatusTerminated
+)
+
+// TaskAction defines the type of action a task performs.
+type TaskAction = internalmodels.TaskAction
+
+// Task action constants.
+const (
+	// TaskActionUnknown              TaskAction = internalmodels.TaskActionUnknown // REMOVED - Not defined internally
+	TaskActionCreateInstances    TaskAction = internalmodels.TaskActionCreateInstances
+	TaskActionTerminateInstances TaskAction = internalmodels.TaskActionTerminateInstances
+	TaskActionDeleteUpload       TaskAction = internalmodels.TaskActionDeleteUpload
+)
+
+// Task represents a background task in the system (public alias).
+type Task = internalmodels.Task
+
+// TaskResult represents the result of a completed task (public alias).
+// type TaskResult = internalmodels.TaskResult // REMOVED - Result is json.RawMessage in internal Task struct
+
+// NOTE: Methods like String(), ParseTaskStatus(), MarshalJSON(), UnmarshalJSON()
+// are defined on the original internal types and are used via the aliases.
+// DO NOT REDEFINE METHODS ON ALIAS TYPES HERE.

--- a/pkg/db/models/users.go
+++ b/pkg/db/models/users.go
@@ -1,0 +1,34 @@
+// Package models contains PUBLIC aliases for database models and related types.
+//
+// NOTE: This package uses type aliases to internal definitions
+// as a temporary measure. This should be revisited
+// during a proper refactoring to define stable public types.
+package models
+
+import (
+	internalmodels "github.com/celestiaorg/talis/internal/db/models"
+)
+
+// UserRole represents the role of a user
+type UserRole = internalmodels.UserRole
+
+// User role constants
+const (
+	UserRoleUser  UserRole = internalmodels.UserRoleUser
+	UserRoleAdmin UserRole = internalmodels.UserRoleAdmin
+)
+
+// User represents a user in the system (public alias).
+type User = internalmodels.User
+
+// Constants related to users
+const (
+	AdminID = internalmodels.AdminID
+)
+
+// Functions related to users (public aliases)
+var (
+	ValidateOwnerID = internalmodels.ValidateOwnerID
+)
+
+// NOTE: Methods are defined on the original internal types.

--- a/pkg/db/models/volume.go
+++ b/pkg/db/models/volume.go
@@ -1,0 +1,18 @@
+// Package models contains PUBLIC aliases for database models and related types.
+//
+// NOTE: This package uses type aliases to internal definitions
+// as a temporary measure. This should be revisited
+// during a proper refactoring to define stable public types.
+package models
+
+import (
+	internalmodels "github.com/celestiaorg/talis/internal/db/models"
+)
+
+// VolumeDetails represents the details of a volume (public alias)
+type VolumeDetails = internalmodels.VolumeDetails
+
+// VolumeDetail represents a block storage volume (public alias)
+type VolumeDetail = internalmodels.VolumeDetail
+
+// NOTE: Methods are defined on the original internal types.

--- a/pkg/types/instance.go
+++ b/pkg/types/instance.go
@@ -1,0 +1,19 @@
+// Package types contains PUBLIC aliases for internal request/response structs.
+//
+// NOTE: This package uses type aliases to internal definitions
+// as a temporary measure. This should be revisited
+// during a proper refactoring to define stable public types.
+package types
+
+import (
+	internaltypes "github.com/celestiaorg/talis/internal/types"
+)
+
+// InstanceRequest defines the structure for requesting instance creation (public alias).
+type InstanceRequest = internaltypes.InstanceRequest
+
+// DeleteInstancesRequest defines the structure for requesting instance deletion (public alias).
+type DeleteInstancesRequest = internaltypes.DeleteInstancesRequest
+
+// PublicIPsResponse defines the structure for the response containing public IPs (public alias).
+type PublicIPsResponse = internaltypes.PublicIPsResponse

--- a/pkg/types/responses.go
+++ b/pkg/types/responses.go
@@ -1,0 +1,23 @@
+// Package types contains PUBLIC aliases for internal request/response structs.
+//
+// NOTE: This package uses type aliases to internal definitions
+// as a temporary measure. This should be revisited
+// during a proper refactoring to define stable public types.
+package types
+
+import (
+	internaltypes "github.com/celestiaorg/talis/internal/types"
+)
+
+// ListResponse is a generic response structure for lists (public alias).
+type ListResponse[T any] struct {
+	Rows  []T `json:"rows"`
+	Total int `json:"total"`
+}
+
+// SlugResponse represents a response containing a slug and potentially data (public alias).
+// NOTE: We alias the internal type directly here as it's generic enough.
+type SlugResponse = internaltypes.SlugResponse
+
+// TaskResponse represents the detailed response for a task operation (public alias).
+type TaskResponse = internaltypes.TaskResponse

--- a/pkg/types/user.go
+++ b/pkg/types/user.go
@@ -1,0 +1,16 @@
+// Package types contains PUBLIC aliases for internal request/response structs.
+//
+// NOTE: This package uses type aliases to internal definitions
+// as a temporary measure. This should be revisited
+// during a proper refactoring to define stable public types.
+package types
+
+import (
+	internaltypes "github.com/celestiaorg/talis/internal/types"
+)
+
+// UserResponse defines the structure for the response containing user details (public alias).
+type UserResponse = internaltypes.UserResponse
+
+// CreateUserResponse defines the structure for the response after creating a user (public alias).
+type CreateUserResponse = internaltypes.CreateUserResponse

--- a/test/api/v1/client_test.go
+++ b/test/api/v1/client_test.go
@@ -196,7 +196,7 @@ func TestClientInstanceMethods(t *testing.T) {
 		ProjectName:   defaultProjectParams.Name,
 		InstanceNames: []string{actualInstances[0].Name, actualInstances[1].Name},
 	}
-	err = suite.APIClient.DeleteInstance(suite.Context(), deleteRequest)
+	err = suite.APIClient.DeleteInstances(suite.Context(), deleteRequest)
 	require.NoError(t, err)
 
 	// Verify the instances eventually get terminated
@@ -225,7 +225,7 @@ func TestClientInstanceMethods(t *testing.T) {
 
 	// Submit the same deletion request again - should be a no-op
 	// We do this after verifying termination to ensure the first deletion completed
-	err = suite.APIClient.DeleteInstance(suite.Context(), deleteRequest)
+	err = suite.APIClient.DeleteInstances(suite.Context(), deleteRequest)
 	require.NoError(t, err)
 
 	// Add a small delay to avoid database lock issues


### PR DESCRIPTION
Since #270 was getting too complex with conflict resolutions and so on, this is a new PR starting from scratch trying to achieve the same thing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced public type aliases for internal models and types, making instance, project, provider, task, user, and volume data structures and constants available for external use.

- **Refactor**
  - Updated method names and usage in the client and CLI to use pluralized forms for instance deletion.
  - Standardized usage of public type aliases across the codebase for improved consistency and maintainability.

- **Tests**
  - Updated tests to use new public type aliases and pluralized method names, improving clarity and alignment with public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->