### PR TITLE
ci: trigger action only when new tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,19 +5,21 @@ on:
     workflows: ["Docker Build & Publish"]
     types:
       - completed
-    branches:
-      # Only trigger for tag-based workflows (releases)
-      - 'refs/tags/**'
   workflow_dispatch:
   release:
     types: [published]
+  # Trigger only on tag creation
+  push:
+    tags:
+      - '*'
 
 jobs:
   deploy:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_ref != '') ||
-      github.event_name == 'release'
+      github.event_name == 'release' ||
+      github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated deployment workflow to trigger on tag pushes, manual dispatch, release events, and specific workflow completions, enabling more flexible and targeted deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->