### PR TITLE
fix: swagger only basic auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,13 +209,14 @@ kong-setup:
 	  --data "name=api" \
 	  --data "url=http://api:8080"
 
-	# 2. Create the route (for example, for /talis)
+	# 2. Create the route for /talis
 	curl -i -X POST http://localhost:8001/services/api/routes \
 	  --data "paths[]=/talis" \
-	  --data "strip_path=true"
+	  --data "strip_path=true" \
+	  --data "name=talis-route"
 
-	# 3. Add the key-auth plugin to the service
-	curl -i -X POST http://localhost:8001/services/api/plugins \
+	# 3. Add the key-auth plugin specifically to the /talis route
+	curl -i -X POST http://localhost:8001/routes/talis-route/plugins \
 	  --data "name=key-auth"
 
 	# 4. Create a consumer


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the setup process to apply authentication specifically to the `/talis` route instead of the entire service.
	- Improved comments for better clarity on how authentication is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->