### PR TITLE
chore: Check if instance exists on the provider side before sending a create…

### DIFF
--- a/internal/compute/provider.go
+++ b/internal/compute/provider.go
@@ -25,6 +25,9 @@ type Provider interface {
 
 	// DeleteInstance deletes an instance
 	DeleteInstance(ctx context.Context, providerInstanceID int) error
+
+	// GetInstanceByTag retrieves an instance by its Talis tag
+	GetInstanceByTag(ctx context.Context, tag string) (*types.InstanceRequest, error)
 }
 
 // Provisioner is the interface for system configuration

--- a/internal/compute/types/digitalocean.go
+++ b/internal/compute/types/digitalocean.go
@@ -26,6 +26,7 @@ type DropletService interface {
 	Get(ctx context.Context, id int) (*godo.Droplet, *godo.Response, error)
 	Delete(ctx context.Context, id int) (*godo.Response, error)
 	List(ctx context.Context, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error)
+	ListByTag(ctx context.Context, tag string, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error)
 }
 
 // KeyService defines the interface for SSH key operations

--- a/internal/compute/ximera.go
+++ b/internal/compute/ximera.go
@@ -4,15 +4,27 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
+	"time"
 
+	ximeraTypes "github.com/celestiaorg/talis/internal/compute/types"
 	"github.com/celestiaorg/talis/internal/constants"
 	"github.com/celestiaorg/talis/internal/logger"
 	"github.com/celestiaorg/talis/internal/types"
 )
 
+// XimeraServerCache holds cached server information
+type XimeraServerCache struct {
+	Servers   *ximeraTypes.XimeraServersListResponse
+	Timestamp time.Time
+	mutex     sync.RWMutex
+}
+
 // XimeraProvider implements the Provider interface for Ximera
 type XimeraProvider struct {
-	client *XimeraAPIClient
+	client   interface{}
+	cache    *XimeraServerCache
+	cacheTTL time.Duration
 }
 
 // NewXimeraProvider creates a new Ximera provider instance
@@ -22,13 +34,45 @@ func NewXimeraProvider() (*XimeraProvider, error) {
 		return nil, fmt.Errorf("failed to initialize ximera config: %w", err)
 	}
 	client := NewXimeraAPIClient(cfg)
-	return &XimeraProvider{client: client}, nil
+	return &XimeraProvider{
+		client: client,
+		cache: &XimeraServerCache{
+			mutex: sync.RWMutex{},
+		},
+		cacheTTL: 5 * time.Minute, // 5 minute cache TTL
+	}, nil
+}
+
+// SetClient sets the client for testing purposes
+func (p *XimeraProvider) SetClient(client interface{}) {
+	p.client = client
+}
+
+// getClient returns the client as XimeraAPIClient interface
+func (p *XimeraProvider) getClient() interface {
+	ListServers() (*ximeraTypes.XimeraServersListResponse, error)
+	CreateServer(name string, packageID int, storage, traffic, memory, cpuCores int) (*ximeraTypes.XimeraServerResponse, error)
+	GetServer(id int) (*ximeraTypes.XimeraServerResponse, error)
+	BuildServer(id int, osID, name, sshKey string) (*ximeraTypes.XimeraServerResponse, error)
+	DeleteServer(id int) error
+	WaitForServerCreation(serverID int, timeoutSeconds int) error
+	GetPackageID() int
+} {
+	return p.client.(interface {
+		ListServers() (*ximeraTypes.XimeraServersListResponse, error)
+		CreateServer(name string, packageID int, storage, traffic, memory, cpuCores int) (*ximeraTypes.XimeraServerResponse, error)
+		GetServer(id int) (*ximeraTypes.XimeraServerResponse, error)
+		BuildServer(id int, osID, name, sshKey string) (*ximeraTypes.XimeraServerResponse, error)
+		DeleteServer(id int) error
+		WaitForServerCreation(serverID int, timeoutSeconds int) error
+		GetPackageID() int
+	})
 }
 
 // ValidateCredentials validates the Ximera credentials
 func (p *XimeraProvider) ValidateCredentials() error {
 	// Try to list servers as a credential check
-	_, err := p.client.ListServers()
+	_, err := p.getClient().ListServers()
 	if err != nil {
 		return fmt.Errorf("ximera credential validation failed: %w", err)
 	}
@@ -78,10 +122,10 @@ func (p *XimeraProvider) CreateInstance(_ context.Context, req *types.InstanceRe
 	// we want each ximera server to have unlimited traffic
 	traffic := 0
 	// Use the configured package ID from the client's configuration
-	packageID := p.client.config.PackageID
+	packageID := p.getClient().GetPackageID()
 
 	// Map InstanceRequest to ximera's CreateServer
-	resp, err := p.client.CreateServer(
+	resp, err := p.getClient().CreateServer(
 		machineName,
 		packageID,
 		req.Volumes[0].SizeGB,
@@ -102,7 +146,7 @@ func (p *XimeraProvider) CreateInstance(_ context.Context, req *types.InstanceRe
 	}
 
 	// Build the server after creation
-	buildResp, err := p.client.BuildServer(resp.Data.ID, req.Image, machineName, sshKeyName)
+	buildResp, err := p.getClient().BuildServer(resp.Data.ID, req.Image, machineName, sshKeyName)
 	if err != nil {
 		return fmt.Errorf("failed to build ximera server: %w", err)
 	}
@@ -111,13 +155,13 @@ func (p *XimeraProvider) CreateInstance(_ context.Context, req *types.InstanceRe
 	}
 
 	// Wait for the server to be fully created (polling with timeout)
-	err = p.client.WaitForServerCreation(buildResp.Data.ID, 120) // 120s timeout
+	err = p.getClient().WaitForServerCreation(buildResp.Data.ID, 120) // 120s timeout
 	if err != nil {
 		return fmt.Errorf("failed to wait for ximera server to be fully created: %w", err)
 	}
 
 	// Get the server details (extract IP here)
-	server, err := p.client.GetServer(buildResp.Data.ID)
+	server, err := p.getClient().GetServer(buildResp.Data.ID)
 	if err != nil {
 		return fmt.Errorf("failed to get ximera server details: %w", err)
 	}
@@ -131,5 +175,110 @@ func (p *XimeraProvider) CreateInstance(_ context.Context, req *types.InstanceRe
 
 // DeleteInstance deletes an instance using Ximera
 func (p *XimeraProvider) DeleteInstance(_ context.Context, providerInstanceID int) error {
-	return p.client.DeleteServer(providerInstanceID)
+	// Invalidate cache after deletion
+	defer p.invalidateCache()
+	return p.getClient().DeleteServer(providerInstanceID)
+}
+
+// invalidateCache invalidates the server cache
+func (p *XimeraProvider) invalidateCache() {
+	p.cache.mutex.Lock()
+	defer p.cache.mutex.Unlock()
+	p.cache.Servers = nil
+	p.cache.Timestamp = time.Time{}
+}
+
+// isCacheValid checks if the cache is still valid
+func (p *XimeraProvider) isCacheValid() bool {
+	p.cache.mutex.RLock()
+	defer p.cache.mutex.RUnlock()
+
+	if p.cache.Servers == nil {
+		return false
+	}
+
+	return time.Since(p.cache.Timestamp) < p.cacheTTL
+}
+
+// getCachedServers retrieves servers from cache with pagination handling
+func (p *XimeraProvider) getCachedServers() (*ximeraTypes.XimeraServersListResponse, error) {
+	// Check if cache is still valid
+	if p.isCacheValid() {
+		p.cache.mutex.RLock()
+		defer p.cache.mutex.RUnlock()
+		logger.Debugf("🗄️ Using cached Ximera servers (%d servers)", len(p.cache.Servers.Data))
+		return p.cache.Servers, nil
+	}
+
+	// Cache is invalid or empty, fetch all servers with pagination
+	logger.Debugf("📥 Fetching all Ximera servers (cache miss or expired)")
+
+	allServers := &ximeraTypes.XimeraServersListResponse{
+		Data: make([]struct {
+			ID           int    `json:"id"`
+			OwnerID      int    `json:"ownerId"`
+			HypervisorID int    `json:"hypervisorId"`
+			Name         string `json:"name"`
+			Hostname     string `json:"hostname"`
+			UUID         string `json:"uuid"`
+			State        string `json:"state"`
+		}, 0),
+	}
+
+	// Note: Ximera's ListServers method should handle pagination internally
+	// If it doesn't, we would need to implement pagination here
+	servers, err := p.getClient().ListServers()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list ximera servers: %w", err)
+	}
+
+	allServers.Data = append(allServers.Data, servers.Data...)
+
+	// Update cache with thread safety
+	p.cache.mutex.Lock()
+	p.cache.Servers = allServers
+	p.cache.Timestamp = time.Now()
+	p.cache.mutex.Unlock()
+
+	logger.Debugf("📦 Cached %d Ximera servers", len(allServers.Data))
+	return allServers, nil
+}
+
+// GetInstanceByTag retrieves an instance by its Talis tag from Ximera using caching
+// Since Ximera doesn't support tags like DigitalOcean, we search by server name
+func (p *XimeraProvider) GetInstanceByTag(_ context.Context, tag string) (*types.InstanceRequest, error) {
+	logger.Debugf("🔍 Searching for Ximera server with tag: %s (using cached data)", tag)
+
+	// Get servers from cache (will fetch if cache is invalid/empty)
+	servers, err := p.getCachedServers()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ximera servers: %w", err)
+	}
+
+	// Search for a server with the tag in its name
+	// For Ximera, we'll look for the tag as part of the server name
+	for _, server := range servers.Data {
+		if server.Name == tag {
+			logger.Debugf("✅ Found Ximera server with tag %s: %s (ID: %d)", tag, server.Name, server.ID)
+
+			// Get full server details to access PublicIP and other fields
+			fullServer, err := p.getClient().GetServer(server.ID)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get full server details for server %d: %w", server.ID, err)
+			}
+
+			// Convert server to InstanceRequest format
+			instanceRequest := &types.InstanceRequest{
+				ProviderInstanceID: fullServer.Data.ID,
+				Name:               fullServer.Data.Name,
+				PublicIP:           fullServer.Data.PublicIP,
+			}
+
+			return instanceRequest, nil
+		}
+	}
+
+	// Instance not found
+	logger.Debugf("❌ No Ximera server found with tag: %s", tag)
+	return nil, fmt.Errorf("instance with tag '%s' not found", tag)
 }

--- a/internal/compute/ximera_api.go
+++ b/internal/compute/ximera_api.go
@@ -290,3 +290,8 @@ func (c *XimeraAPIClient) WaitForServerCreation(serverID int, timeoutSeconds int
 		}
 	}
 }
+
+// GetPackageID returns the configured package ID
+func (c *XimeraAPIClient) GetPackageID() int {
+	return c.config.PackageID
+}

--- a/internal/compute/ximera_test.go
+++ b/internal/compute/ximera_test.go
@@ -1,0 +1,695 @@
+package compute
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	ximeraTypes "github.com/celestiaorg/talis/internal/compute/types"
+	"github.com/celestiaorg/talis/internal/constants"
+	"github.com/celestiaorg/talis/internal/types"
+	"github.com/celestiaorg/talis/test/mocks"
+)
+
+// Test helper functions
+
+// newTestXimeraProvider creates a new XimeraProvider with a mock client for testing
+func newTestXimeraProvider() (*XimeraProvider, *mocks.MockXimeraAPIClient) {
+	mockClient := mocks.NewMockXimeraAPIClient()
+	provider := &XimeraProvider{
+		cache: &XimeraServerCache{
+			mutex: sync.RWMutex{},
+		},
+		cacheTTL: 5 * time.Minute,
+	}
+	provider.SetClient(mockClient)
+	return provider, mockClient
+}
+
+// newTestXimeraProviderWithShortTTL creates a provider with a short cache TTL for testing cache expiration
+func newTestXimeraProviderWithShortTTL() (*XimeraProvider, *mocks.MockXimeraAPIClient) {
+	mockClient := mocks.NewMockXimeraAPIClient()
+	provider := &XimeraProvider{
+		cache: &XimeraServerCache{
+			mutex: sync.RWMutex{},
+		},
+		cacheTTL: 100 * time.Millisecond, // Very short TTL for testing
+	}
+	provider.SetClient(mockClient)
+	return provider, mockClient
+}
+
+// Tests grouped by interface/struct implementation
+
+// XimeraProvider struct and methods tests
+
+// TestXimeraProvider tests the basic provider functionality
+func TestXimeraProvider(t *testing.T) {
+	// Save and restore environment variables
+	originalAPIURL := os.Getenv("XIMERA_API_URL")
+	originalAPIToken := os.Getenv("XIMERA_API_TOKEN")
+	originalUserID := os.Getenv("XIMERA_USER_ID")
+	originalHypervisorID := os.Getenv("XIMERA_HYPERVISOR_GROUP_ID")
+	originalPackageID := os.Getenv("XIMERA_PACKAGE_ID")
+	originalSSHKeyName := os.Getenv(constants.EnvTalisSSHKeyName)
+
+	defer func() {
+		os.Setenv("XIMERA_API_URL", originalAPIURL)
+		os.Setenv("XIMERA_API_TOKEN", originalAPIToken)
+		os.Setenv("XIMERA_USER_ID", originalUserID)
+		os.Setenv("XIMERA_HYPERVISOR_GROUP_ID", originalHypervisorID)
+		os.Setenv("XIMERA_PACKAGE_ID", originalPackageID)
+		os.Setenv(constants.EnvTalisSSHKeyName, originalSSHKeyName)
+	}()
+
+	// Set required environment variables for tests
+	os.Setenv("XIMERA_API_URL", "https://api.ximera.test")
+	os.Setenv("XIMERA_API_TOKEN", "test-token")
+	os.Setenv("XIMERA_USER_ID", "100")
+	os.Setenv("XIMERA_HYPERVISOR_GROUP_ID", "10")
+	os.Setenv("XIMERA_PACKAGE_ID", "1")
+	os.Setenv(constants.EnvTalisSSHKeyName, "123")
+
+	t.Run("NewXimeraProvider_Success", func(t *testing.T) {
+		provider, err := NewXimeraProvider()
+		assert.NoError(t, err)
+		assert.NotNil(t, provider)
+		assert.NotNil(t, provider.client)
+		assert.NotNil(t, provider.cache)
+		assert.Equal(t, 5*time.Minute, provider.cacheTTL)
+	})
+
+	t.Run("NewXimeraProvider_MissingConfig", func(t *testing.T) {
+		// Clear required env var
+		os.Setenv("XIMERA_API_URL", "")
+
+		provider, err := NewXimeraProvider()
+		assert.Error(t, err)
+		assert.Nil(t, provider)
+		assert.Contains(t, err.Error(), "failed to initialize ximera config")
+
+		// Restore for other tests
+		os.Setenv("XIMERA_API_URL", "https://api.ximera.test")
+	})
+
+	t.Run("ValidateCredentials_Success", func(t *testing.T) {
+		provider, _ := newTestXimeraProvider()
+		err := provider.ValidateCredentials()
+		assert.NoError(t, err)
+	})
+
+	t.Run("ValidateCredentials_Error", func(t *testing.T) {
+		provider, mockClient := newTestXimeraProvider()
+		mockClient.SimulateAuthenticationFailure()
+
+		err := provider.ValidateCredentials()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "ximera credential validation failed")
+	})
+
+	t.Run("GetEnvironmentVars", func(t *testing.T) {
+		provider, _ := newTestXimeraProvider()
+		envVars := provider.GetEnvironmentVars()
+
+		expectedVars := []string{
+			"XIMERA_API_URL",
+			"XIMERA_API_TOKEN",
+			"XIMERA_USER_ID",
+			"XIMERA_HYPERVISOR_GROUP_ID",
+			"XIMERA_PACKAGE_ID",
+		}
+
+		for _, envVar := range expectedVars {
+			_, exists := envVars[envVar]
+			assert.True(t, exists, "Environment variable %s should be present", envVar)
+		}
+	})
+
+	t.Run("ConfigureProvider", func(t *testing.T) {
+		provider, _ := newTestXimeraProvider()
+		err := provider.ConfigureProvider(nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("SetClient", func(t *testing.T) {
+		provider := &XimeraProvider{}
+		mockClient := mocks.NewMockXimeraAPIClient()
+
+		// Initially the client should be nil
+		assert.Nil(t, provider.client)
+
+		// Set the client
+		provider.SetClient(mockClient)
+
+		// Verify the client was set
+		assert.NotNil(t, provider.client)
+		assert.Equal(t, mockClient, provider.client)
+	})
+}
+
+// TestXimeraProviderCreateInstance tests the CreateInstance functionality
+func TestXimeraProviderCreateInstance(t *testing.T) {
+	// Set required environment variables
+	os.Setenv(constants.EnvTalisSSHKeyName, "123")
+	defer os.Unsetenv(constants.EnvTalisSSHKeyName)
+
+	t.Run("CreateInstance_Success", func(t *testing.T) {
+		provider, _ := newTestXimeraProvider()
+
+		req := &types.InstanceRequest{
+			ProjectName: "test-project",
+			Image:       "200", // Use string format as expected by Ximera
+			Memory:      2048,
+			CPU:         2,
+			Volumes: []types.VolumeConfig{
+				{
+					Name:       "test-volume",
+					SizeGB:     20,
+					MountPoint: "/data",
+				},
+			},
+		}
+
+		err := provider.CreateInstance(context.Background(), req)
+		assert.NoError(t, err)
+		assert.NotZero(t, req.ProviderInstanceID)
+		assert.NotEmpty(t, req.PublicIP)
+	})
+
+	t.Run("CreateInstance_NoVolumes", func(t *testing.T) {
+		provider, _ := newTestXimeraProvider()
+
+		req := &types.InstanceRequest{
+			ProjectName: "test-project",
+			Image:       "200",
+			Memory:      2048,
+			CPU:         2,
+			Volumes:     []types.VolumeConfig{}, // Empty volumes
+		}
+
+		err := provider.CreateInstance(context.Background(), req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no volume details provided")
+	})
+
+	t.Run("CreateInstance_MultipleVolumes", func(t *testing.T) {
+		provider, _ := newTestXimeraProvider()
+
+		req := &types.InstanceRequest{
+			ProjectName: "test-project",
+			Image:       "200",
+			Memory:      2048,
+			CPU:         2,
+			Volumes: []types.VolumeConfig{
+				{Name: "volume1", SizeGB: 20},
+				{Name: "volume2", SizeGB: 30}, // Multiple volumes not supported
+			},
+		}
+
+		err := provider.CreateInstance(context.Background(), req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "only one volume is supported")
+	})
+
+	t.Run("CreateInstance_MissingMemory", func(t *testing.T) {
+		provider, _ := newTestXimeraProvider()
+
+		req := &types.InstanceRequest{
+			ProjectName: "test-project",
+			Image:       "200",
+			CPU:         2,
+			Volumes:     []types.VolumeConfig{{Name: "test", SizeGB: 20}},
+			// Memory missing
+		}
+
+		err := provider.CreateInstance(context.Background(), req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "memory is required for Ximera")
+	})
+
+	t.Run("CreateInstance_MissingCPU", func(t *testing.T) {
+		provider, _ := newTestXimeraProvider()
+
+		req := &types.InstanceRequest{
+			ProjectName: "test-project",
+			Image:       "200",
+			Memory:      2048,
+			Volumes:     []types.VolumeConfig{{Name: "test", SizeGB: 20}},
+			// CPU missing
+		}
+
+		err := provider.CreateInstance(context.Background(), req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cpu is required for Ximera")
+	})
+
+	t.Run("CreateInstance_MissingSSHKey", func(t *testing.T) {
+		provider, _ := newTestXimeraProvider()
+		os.Unsetenv(constants.EnvTalisSSHKeyName) // Remove SSH key env var
+
+		req := &types.InstanceRequest{
+			ProjectName: "test-project",
+			Image:       "200",
+			Memory:      2048,
+			CPU:         2,
+			Volumes:     []types.VolumeConfig{{Name: "test", SizeGB: 20}},
+		}
+
+		err := provider.CreateInstance(context.Background(), req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "environment variable")
+		assert.Contains(t, err.Error(), "is not set but required for Ximera")
+
+		// Restore for other tests
+		os.Setenv(constants.EnvTalisSSHKeyName, "123")
+	})
+
+	t.Run("CreateInstance_CreateServerError", func(t *testing.T) {
+		provider, mockClient := newTestXimeraProvider()
+		mockClient.SimulateServerCreationError()
+
+		req := &types.InstanceRequest{
+			ProjectName: "test-project",
+			Image:       "200",
+			Memory:      2048,
+			CPU:         2,
+			Volumes:     []types.VolumeConfig{{Name: "test", SizeGB: 20}},
+		}
+
+		err := provider.CreateInstance(context.Background(), req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create ximera server")
+	})
+
+	t.Run("CreateInstance_SizeParameterWarning", func(t *testing.T) {
+		provider, _ := newTestXimeraProvider()
+
+		req := &types.InstanceRequest{
+			ProjectName: "test-project",
+			Image:       "200",
+			Memory:      2048,
+			CPU:         2,
+			Size:        "s-1vcpu-1gb", // This should trigger a warning
+			Volumes:     []types.VolumeConfig{{Name: "test", SizeGB: 20}},
+		}
+
+		err := provider.CreateInstance(context.Background(), req)
+		assert.NoError(t, err) // Should still succeed but with warning
+	})
+}
+
+// TestXimeraProviderDeleteInstance tests the DeleteInstance functionality
+func TestXimeraProviderDeleteInstance(t *testing.T) {
+	t.Run("DeleteInstance_Success", func(t *testing.T) {
+		provider, _ := newTestXimeraProvider()
+
+		err := provider.DeleteInstance(context.Background(), mocks.DefaultXimeraServerID1)
+		assert.NoError(t, err)
+	})
+
+	t.Run("DeleteInstance_NotFound", func(t *testing.T) {
+		provider, mockClient := newTestXimeraProvider()
+		mockClient.SimulateNotFound()
+
+		err := provider.DeleteInstance(context.Background(), 99999)
+		assert.Error(t, err)
+		assert.Equal(t, mocks.ErrXimeraServerNotFound, err)
+	})
+
+	t.Run("DeleteInstance_InvalidatesCache", func(t *testing.T) {
+		provider, _ := newTestXimeraProvider()
+
+		// First, populate the cache
+		_, err := provider.getCachedServers()
+		assert.NoError(t, err)
+		assert.True(t, provider.isCacheValid())
+
+		// Delete an instance, which should invalidate the cache
+		err = provider.DeleteInstance(context.Background(), mocks.DefaultXimeraServerID1)
+		assert.NoError(t, err)
+
+		// Cache should be invalidated
+		assert.False(t, provider.isCacheValid())
+	})
+}
+
+// TestXimeraProviderCaching tests the caching mechanism
+func TestXimeraProviderCaching(t *testing.T) {
+	t.Run("getCachedServers_CacheMiss", func(t *testing.T) {
+		provider, mockClient := newTestXimeraProvider()
+
+		// Cache should be empty initially
+		assert.False(t, provider.isCacheValid())
+
+		// First call should fetch from API
+		servers, err := provider.getCachedServers()
+		assert.NoError(t, err)
+		assert.NotNil(t, servers)
+		assert.Len(t, servers.Data, 2) // Default mock returns 2 servers
+
+		// Cache should now be valid
+		assert.True(t, provider.isCacheValid())
+
+		// Verify it was called once
+		assert.Equal(t, 1, mockClient.GetAttemptCount())
+	})
+
+	t.Run("getCachedServers_CacheHit", func(t *testing.T) {
+		provider, mockClient := newTestXimeraProvider()
+
+		// First call to populate cache
+		servers1, err := provider.getCachedServers()
+		assert.NoError(t, err)
+		assert.NotNil(t, servers1)
+
+		// Reset attempt count to track cache hits
+		mockClient.ResetAttemptCount()
+
+		// Second call should use cache
+		servers2, err := provider.getCachedServers()
+		assert.NoError(t, err)
+		assert.NotNil(t, servers2)
+		assert.Equal(t, servers1, servers2) // Should be same data
+
+		// Should not have called API again
+		assert.Equal(t, 0, mockClient.GetAttemptCount())
+	})
+
+	t.Run("getCachedServers_CacheExpiry", func(t *testing.T) {
+		provider, mockClient := newTestXimeraProviderWithShortTTL()
+
+		// First call to populate cache
+		_, err := provider.getCachedServers()
+		assert.NoError(t, err)
+		assert.True(t, provider.isCacheValid())
+
+		// Wait for cache to expire
+		time.Sleep(150 * time.Millisecond)
+		assert.False(t, provider.isCacheValid())
+
+		// Reset attempt count
+		mockClient.ResetAttemptCount()
+
+		// Next call should fetch from API again
+		_, err = provider.getCachedServers()
+		assert.NoError(t, err)
+
+		// Should have called API again
+		assert.Equal(t, 1, mockClient.GetAttemptCount())
+	})
+
+	t.Run("isCacheValid_EmptyCache", func(t *testing.T) {
+		provider, _ := newTestXimeraProvider()
+		assert.False(t, provider.isCacheValid())
+	})
+
+	t.Run("invalidateCache", func(t *testing.T) {
+		provider, _ := newTestXimeraProvider()
+
+		// Populate cache
+		_, err := provider.getCachedServers()
+		assert.NoError(t, err)
+		assert.True(t, provider.isCacheValid())
+
+		// Invalidate cache
+		provider.invalidateCache()
+		assert.False(t, provider.isCacheValid())
+	})
+
+	t.Run("getCachedServers_APIError", func(t *testing.T) {
+		provider, mockClient := newTestXimeraProvider()
+		mockClient.SimulateNetworkError()
+
+		_, err := provider.getCachedServers()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to list ximera servers")
+	})
+}
+
+// TestXimeraProviderGetInstanceByTag tests the search by tag functionality
+func TestXimeraProviderGetInstanceByTag(t *testing.T) {
+	t.Run("GetInstanceByTag_Found", func(t *testing.T) {
+		provider, mockClient := newTestXimeraProvider()
+		mockClient.SimulateServerListWithTag() // Use server list containing the tag
+
+		instance, err := provider.GetInstanceByTag(context.Background(), mocks.TestTagName)
+		assert.NoError(t, err)
+		assert.NotNil(t, instance)
+		assert.Equal(t, mocks.DefaultXimeraServerID2, instance.ProviderInstanceID)
+		assert.Equal(t, mocks.TestTagName, instance.Name)
+		assert.Equal(t, mocks.DefaultXimeraServerIP2, instance.PublicIP)
+	})
+
+	t.Run("GetInstanceByTag_NotFound", func(t *testing.T) {
+		provider, mockClient := newTestXimeraProvider()
+		mockClient.SimulateEmptyServerList() // No servers to search
+
+		instance, err := provider.GetInstanceByTag(context.Background(), "nonexistent-tag")
+		assert.Error(t, err)
+		assert.Nil(t, instance)
+		assert.Contains(t, err.Error(), "instance with tag 'nonexistent-tag' not found")
+	})
+
+	t.Run("GetInstanceByTag_NotFoundInNonEmptyList", func(t *testing.T) {
+		provider, _ := newTestXimeraProvider()
+		// Default server list doesn't contain the tag we're looking for
+
+		instance, err := provider.GetInstanceByTag(context.Background(), "nonexistent-tag")
+		assert.Error(t, err)
+		assert.Nil(t, instance)
+		assert.Contains(t, err.Error(), "instance with tag 'nonexistent-tag' not found")
+	})
+
+	t.Run("GetInstanceByTag_UsesCaching", func(t *testing.T) {
+		provider, mockClient := newTestXimeraProvider()
+		mockClient.SimulateServerListWithTag()
+
+		// First call should populate cache
+		_, err := provider.GetInstanceByTag(context.Background(), mocks.TestTagName)
+		assert.NoError(t, err)
+		assert.True(t, provider.isCacheValid())
+
+		// Reset attempt count to track cache usage
+		mockClient.ResetAttemptCount()
+
+		// Second call should use cache for ListServers but still call GetServer
+		_, err = provider.GetInstanceByTag(context.Background(), mocks.TestTagName)
+		assert.NoError(t, err)
+
+		// Should only have called GetServer (1 attempt), not ListServers again
+		assert.Equal(t, 1, mockClient.GetAttemptCount())
+	})
+
+	t.Run("GetInstanceByTag_APIError", func(t *testing.T) {
+		provider, mockClient := newTestXimeraProvider()
+		mockClient.SimulateNetworkError()
+
+		instance, err := provider.GetInstanceByTag(context.Background(), mocks.TestTagName)
+		assert.Error(t, err)
+		assert.Nil(t, instance)
+		assert.Contains(t, err.Error(), "failed to get ximera servers")
+	})
+
+	t.Run("GetInstanceByTag_GetServerDetailsError", func(t *testing.T) {
+		provider, mockClient := newTestXimeraProvider()
+		mockClient.SimulateServerListWithTag()
+
+		// Configure GetServer to fail
+		mockClient.GetServerFunc = func(id int) (*ximeraTypes.XimeraServerResponse, error) {
+			return nil, mocks.ErrXimeraServerNotFound
+		}
+
+		instance, err := provider.GetInstanceByTag(context.Background(), mocks.TestTagName)
+		assert.Error(t, err)
+		assert.Nil(t, instance)
+		assert.Contains(t, err.Error(), "failed to get full server details")
+	})
+
+	t.Run("GetInstanceByTag_ExactMatch", func(t *testing.T) {
+		provider, mockClient := newTestXimeraProvider()
+
+		// Create a custom server list with partial matches to ensure exact matching
+		customServerList := &ximeraTypes.XimeraServersListResponse{
+			Data: []struct {
+				ID           int    `json:"id"`
+				OwnerID      int    `json:"ownerId"`
+				HypervisorID int    `json:"hypervisorId"`
+				Name         string `json:"name"`
+				Hostname     string `json:"hostname"`
+				UUID         string `json:"uuid"`
+				State        string `json:"state"`
+			}{
+				{
+					ID:   1,
+					Name: "talis-123-456-suffix", // Should not match "talis-123-456"
+				},
+				{
+					ID:   2,
+					Name: "prefix-talis-123-456", // Should not match "talis-123-456"
+				},
+				{
+					ID:   3,
+					Name: mocks.TestTagName, // Exact match - should be found
+				},
+			},
+		}
+
+		mockClient.ListServersFunc = func() (*ximeraTypes.XimeraServersListResponse, error) {
+			return customServerList, nil
+		}
+
+		instance, err := provider.GetInstanceByTag(context.Background(), mocks.TestTagName)
+		assert.NoError(t, err)
+		assert.NotNil(t, instance)
+		assert.Equal(t, 3, instance.ProviderInstanceID) // Should find the exact match (ID 3)
+	})
+}
+
+// TestXimeraProviderConcurrency tests concurrent access to caching
+func TestXimeraProviderConcurrency(t *testing.T) {
+	t.Run("ConcurrentCacheAccess", func(t *testing.T) {
+		provider, _ := newTestXimeraProvider()
+
+		// Run multiple goroutines accessing cache concurrently
+		const numGoroutines = 10
+		results := make(chan error, numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func() {
+				_, err := provider.getCachedServers()
+				results <- err
+			}()
+		}
+
+		// Wait for all goroutines to complete
+		for i := 0; i < numGoroutines; i++ {
+			err := <-results
+			assert.NoError(t, err)
+		}
+	})
+
+	t.Run("ConcurrentGetInstanceByTag", func(t *testing.T) {
+		provider, mockClient := newTestXimeraProvider()
+		mockClient.SimulateServerListWithTag()
+
+		// Run multiple goroutines searching by tag concurrently
+		const numGoroutines = 5
+		results := make(chan error, numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func() {
+				_, err := provider.GetInstanceByTag(context.Background(), mocks.TestTagName)
+				results <- err
+			}()
+		}
+
+		// Wait for all goroutines to complete
+		for i := 0; i < numGoroutines; i++ {
+			err := <-results
+			assert.NoError(t, err)
+		}
+	})
+}
+
+// TestXimeraProviderEdgeCases tests edge cases and error scenarios
+func TestXimeraProviderEdgeCases(t *testing.T) {
+	t.Run("EmptyTagSearch", func(t *testing.T) {
+		provider, _ := newTestXimeraProvider()
+
+		instance, err := provider.GetInstanceByTag(context.Background(), "")
+		assert.Error(t, err)
+		assert.Nil(t, instance)
+		assert.Contains(t, err.Error(), "instance with tag '' not found")
+	})
+
+	t.Run("CacheThreadSafety_InvalidateWhileReading", func(t *testing.T) {
+		provider, _ := newTestXimeraProvider()
+
+		// Populate cache
+		_, err := provider.getCachedServers()
+		assert.NoError(t, err)
+
+		// Simulate concurrent access: one goroutine reading, another invalidating
+		done := make(chan bool)
+		go func() {
+			provider.invalidateCache()
+			done <- true
+		}()
+
+		// Should not panic or cause race condition
+		provider.isCacheValid()
+
+		<-done // Wait for invalidation goroutine to complete
+	})
+
+	t.Run("CacheWithNilServers", func(t *testing.T) {
+		provider, _ := newTestXimeraProvider()
+
+		// Manually set cache to nil servers
+		provider.cache.Servers = nil
+		provider.cache.Timestamp = time.Now()
+
+		// Cache should be considered invalid
+		assert.False(t, provider.isCacheValid())
+	})
+}
+
+// TestXimeraProviderIntegration tests integration scenarios
+func TestXimeraProviderIntegration(t *testing.T) {
+	t.Run("CreateThenFindByTag", func(t *testing.T) {
+		provider, mockClient := newTestXimeraProvider()
+
+		// Set up environment
+		os.Setenv(constants.EnvTalisSSHKeyName, "123")
+		defer os.Unsetenv(constants.EnvTalisSSHKeyName)
+
+		// Create an instance
+		req := &types.InstanceRequest{
+			ProjectName: mocks.TestTagName, // Use the tag name as project name
+			Image:       "200",
+			Memory:      2048,
+			CPU:         2,
+			Volumes:     []types.VolumeConfig{{Name: "test", SizeGB: 20}},
+		}
+
+		err := provider.CreateInstance(context.Background(), req)
+		assert.NoError(t, err)
+
+		// Mock the server list to include our created server
+		mockClient.SimulateServerListWithTag()
+
+		// Try to find it by tag
+		foundInstance, err := provider.GetInstanceByTag(context.Background(), mocks.TestTagName)
+		assert.NoError(t, err)
+		assert.NotNil(t, foundInstance)
+		assert.Equal(t, mocks.TestTagName, foundInstance.Name)
+	})
+
+	t.Run("DeleteInvalidatesSearchCache", func(t *testing.T) {
+		provider, mockClient := newTestXimeraProvider()
+		mockClient.SimulateServerListWithTag()
+
+		// First, find instance by tag (populates cache)
+		instance, err := provider.GetInstanceByTag(context.Background(), mocks.TestTagName)
+		assert.NoError(t, err)
+		assert.NotNil(t, instance)
+		assert.True(t, provider.isCacheValid())
+
+		// Delete the instance (should invalidate cache)
+		err = provider.DeleteInstance(context.Background(), instance.ProviderInstanceID)
+		assert.NoError(t, err)
+		assert.False(t, provider.isCacheValid())
+
+		// Next search should fetch fresh data
+		mockClient.ResetAttemptCount()
+		mockClient.SimulateEmptyServerList() // Now return empty list
+
+		_, err = provider.GetInstanceByTag(context.Background(), mocks.TestTagName)
+		assert.Error(t, err) // Should not find it anymore
+		assert.Contains(t, err.Error(), "not found")
+	})
+}

--- a/internal/services/instance_test.go
+++ b/internal/services/instance_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"testing"
 
@@ -144,6 +145,12 @@ func TestInstanceService_CreateInstance_SetsTaskInstanceID(t *testing.T) {
 	var taskPayload types.InstanceRequest
 	err = json.Unmarshal(tasks[0].Payload, &taskPayload)
 	assert.NoError(t, err)
+
+	// Add debug output
+	fmt.Printf("DEBUG TEST: Task InstanceID in DB: %d\n", tasks[0].InstanceID)
+	fmt.Printf("DEBUG TEST: Task Payload InstanceID: %d\n", taskPayload.InstanceID)
+	fmt.Printf("DEBUG TEST: Expected InstanceID: %d\n", expectedInstanceID)
+
 	assert.Equal(t, expectedInstanceID, taskPayload.InstanceID)
 }
 

--- a/internal/types/instance.go
+++ b/internal/types/instance.go
@@ -18,18 +18,19 @@ const maxPayloadSize = 2 * 1024 * 1024 // 2MB
 // Example: {"owner_id":1,"provider":"do","region":"nyc1","size":"s-1vcpu-1gb","image":"ubuntu-20-04-x64","tags":["webserver","production"],"project_name":"my-web-project","ssh_key_name":"my-ssh-key","number_of_instances":2,"provision":true,"payload_path":"/path/to/your/script.sh","execute_payload":true,"volumes":[{"name":"my-volume-1","size_gb":10,"mount_point":"/mnt/data"}]}
 type InstanceRequest struct {
 	// DB Model Data - User Defined
-	OwnerID  uint              `json:"owner_id"` // Owner ID of the instance
-	Provider models.ProviderID `json:"provider"` // Cloud provider (e.g., "do")
-	Region   string            `json:"region"`   // Region where instances will be created
-	Size     string            `json:"size"`     // Instance size/type (used for cloud provider with predefined sizes)
-	Memory   int               `json:"memory"`   // Memory in MB (used for Ximera to allow custom memory)
-	CPU      int               `json:"cpu"`      // CPU cores (used for Ximera to allow custom CPU)
-	Image    string            `json:"image"`    // OS image to use
-	Tags     []string          `json:"tags"`     // Tags to apply to instances
+	OwnerID   uint              `json:"owner_id"` // Owner ID of the instance
+	ProjectID uint              `json:"-"`        // This is not user defined, it is set by the server
+	Provider  models.ProviderID `json:"provider"` // Cloud provider (e.g., "do")
+	Region    string            `json:"region"`   // Region where instances will be created
+	Size      string            `json:"size"`     // Instance size/type (used for cloud provider with predefined sizes)
+	Memory    int               `json:"memory"`   // Memory in MB (used for Ximera to allow custom memory)
+	CPU       int               `json:"cpu"`      // CPU cores (used for Ximera to allow custom CPU)
+	Image     string            `json:"image"`    // OS image to use
+	Tags      []string          `json:"tags"`     // Tags to apply to instances
 
 	// DB Model Data - Internally set during creation
-	InstanceID    uint            `json:"instance_id"`              // Instance ID
-	PublicIP      string          `json:"public_ip"`                // Public IP address
+	InstanceID    uint            `json:"instance_id,omitempty"`    // Instance ID
+	PublicIP      string          `json:"-"`                        // Public IP address
 	VolumeIDs     []string        `json:"volume_ids,omitempty"`     // List of attached volume IDs
 	VolumeDetails []VolumeDetails `json:"volume_details,omitempty"` // Detailed information about attached volumes
 
@@ -172,4 +173,9 @@ func (i *InstanceRequest) Validate() error {
 	}
 
 	return nil
+}
+
+// GenerateProviderTag creates a standardized tag for identifying instances on cloud providers
+func GenerateProviderTag(projectID, instanceID uint) string {
+	return fmt.Sprintf("talis-%d-%d", projectID, instanceID)
 }

--- a/pkg/api/v1/handlers/errors.go
+++ b/pkg/api/v1/handlers/errors.go
@@ -54,6 +54,17 @@ const (
 	ErrMsgNilUserObject          = "User object is nil"
 )
 
+// SSH key error messages
+const (
+	ErrMsgSSHKeyNameRequired    = "SSH key name is required"
+	ErrMsgSSHKeyOwnerIDRequired = "SSH key owner_id is required"
+	ErrMsgSSHKeyNotFound        = "SSH key not found"
+	ErrMsgSSHKeyCreateFailed    = "Failed to create SSH key"
+	ErrMsgSSHKeyListFailed      = "Failed to list SSH keys"
+	ErrMsgSSHKeyDeleteFailed    = "Failed to delete SSH key"
+	ErrMsgSSHKeyAlreadyExists   = "SSH key with this name already exists"
+)
+
 // Pagination error messages
 const (
 	ErrMsgNegativePagination = "Page must be a positive number from 1"

--- a/test/api/v1/client_test.go
+++ b/test/api/v1/client_test.go
@@ -54,6 +54,7 @@ var defaultInstanceRequest1 = types.InstanceRequest{
 	Region:            "nyc1",
 	Size:              "s-1vcpu-1gb",
 	Image:             "ubuntu-20-04-x64",
+	Provision:         false, // Explicitly disable provisioning for tests
 	Volumes: []types.VolumeConfig{
 		{
 			Name:       "test-volume",
@@ -72,6 +73,7 @@ var defaultInstanceRequest2 = types.InstanceRequest{
 	Region:            "nyc1",
 	Size:              "s-1vcpu-1gb",
 	Image:             "ubuntu-20-04-x64",
+	Provision:         false, // Explicitly disable provisioning for tests
 	Volumes: []types.VolumeConfig{
 		{
 			Name:       "test-volume",
@@ -304,6 +306,7 @@ func TestClient_ListTasksByInstanceID(t *testing.T) {
 		{
 			Provider: models.ProviderID("digitalocean-mock"), OwnerID: models.AdminID, NumberOfInstances: 1,
 			ProjectName: project.Name, Region: "sfo3", Size: "s-1vcpu-1gb", Image: "ubuntu-22-04-x64",
+			Provision: false, // Explicitly disable provisioning for tests
 			Volumes: []types.VolumeConfig{{
 				Name: "vol-inst1", SizeGB: 5, MountPoint: "/mnt/data", Region: "sfo3", FileSystem: "ext4",
 			}},
@@ -311,6 +314,7 @@ func TestClient_ListTasksByInstanceID(t *testing.T) {
 		{
 			Provider: models.ProviderID("digitalocean-mock"), OwnerID: models.AdminID, NumberOfInstances: 1,
 			ProjectName: project.Name, Region: "ams3", Size: "s-2vcpu-2gb", Image: "fedora-38-x64",
+			Provision: false, // Explicitly disable provisioning for tests
 			Volumes: []types.VolumeConfig{{
 				Name: "vol-inst2", SizeGB: 8, MountPoint: "/mnt/data", Region: "ams3", FileSystem: "xfs",
 			}},

--- a/test/mocks/ximera.go
+++ b/test/mocks/ximera.go
@@ -1,0 +1,542 @@
+// Package mocks provides mock implementations for external services and APIs used in testing
+package mocks
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	ximeraTypes "github.com/celestiaorg/talis/internal/compute/types"
+)
+
+// MockXimeraAPIClient implements a mock version of XimeraAPIClient for testing
+type MockXimeraAPIClient struct {
+	StandardResponses *XimeraStandardResponses
+	// Function mocks for different API calls
+	ListServersFunc           func() (*ximeraTypes.XimeraServersListResponse, error)
+	CreateServerFunc          func(name string, packageID int, storage, traffic, memory, cpuCores int) (*ximeraTypes.XimeraServerResponse, error)
+	GetServerFunc             func(id int) (*ximeraTypes.XimeraServerResponse, error)
+	BuildServerFunc           func(id int, osID, name, sshKey string) (*ximeraTypes.XimeraServerResponse, error)
+	DeleteServerFunc          func(id int) error
+	ServerExistsFunc          func(name string) (bool, int, error)
+	ListTemplatesFunc         func(packageID int) (*ximeraTypes.XimeraTemplatesResponse, error)
+	WaitForServerCreationFunc func(serverID int, timeoutSeconds int) error
+	// State tracking for testing
+	mutex        sync.Mutex
+	attemptCount int
+	nextID       int
+}
+
+// XimeraStandardResponses holds standard mock responses for Ximera API calls
+type XimeraStandardResponses struct {
+	Servers   *XimeraServerResponses
+	Templates *XimeraTemplateResponses
+	Errors    *XimeraErrorResponses
+}
+
+// XimeraServerResponses holds standard server-related responses
+type XimeraServerResponses struct {
+	DefaultServer     *ximeraTypes.XimeraServerResponse
+	DefaultServerList *ximeraTypes.XimeraServersListResponse
+	EmptyServerList   *ximeraTypes.XimeraServersListResponse
+	ServerWithTag     *ximeraTypes.XimeraServerResponse
+	ServerListWithTag *ximeraTypes.XimeraServersListResponse
+}
+
+// XimeraTemplateResponses holds standard template-related responses
+type XimeraTemplateResponses struct {
+	DefaultTemplates *ximeraTypes.XimeraTemplatesResponse
+}
+
+// XimeraErrorResponses holds standard error responses
+type XimeraErrorResponses struct {
+	NotFoundError       error
+	AuthenticationError error
+	RateLimitError      error
+	ServerCreationError error
+	NetworkError        error
+}
+
+// Test constants for Ximera
+const (
+	DefaultXimeraServerID1   = 12345
+	DefaultXimeraServerID2   = 12346
+	DefaultXimeraServerIP1   = "203.0.113.10"
+	DefaultXimeraServerIP2   = "203.0.113.11"
+	DefaultXimeraServerName1 = "test-server-1"
+	DefaultXimeraServerName2 = "test-server-2"
+	TestTagName              = "talis-123-456"
+	DefaultPackageID         = 1
+	DefaultHypervisorID      = 10
+	DefaultUserID            = 100
+	DefaultTemplateID        = 200
+)
+
+// Common errors
+var (
+	ErrXimeraServerNotFound = fmt.Errorf("server not found")
+	ErrXimeraUnauthorized   = fmt.Errorf("unauthorized access")
+	ErrXimeraRateLimit      = fmt.Errorf("rate limit exceeded")
+	ErrXimeraNetwork        = fmt.Errorf("network error")
+)
+
+// NewXimeraStandardResponses creates standard mock responses for Ximera
+func NewXimeraStandardResponses() *XimeraStandardResponses {
+	return &XimeraStandardResponses{
+		Servers:   newXimeraServerResponses(),
+		Templates: newXimeraTemplateResponses(),
+		Errors:    newXimeraErrorResponses(),
+	}
+}
+
+// newXimeraServerResponses creates standard server responses
+func newXimeraServerResponses() *XimeraServerResponses {
+	// Create default server response
+	defaultServer := &ximeraTypes.XimeraServerResponse{
+		Data: struct {
+			ID               int    `json:"id"`
+			OwnerID          int    `json:"ownerId"`
+			HypervisorID     int    `json:"hypervisorId"`
+			Name             string `json:"name"`
+			Hostname         string `json:"hostname"`
+			UUID             string `json:"uuid"`
+			State            string `json:"state"`
+			CommissionStatus int    `json:"commissionStatus"`
+			PublicIP         string `json:"publicIp,omitempty"`
+			Created          string `json:"created"`
+			Updated          string `json:"updated"`
+			Network          struct {
+				Interfaces []struct {
+					IPv4 []struct {
+						Address string `json:"address"`
+					} `json:"ipv4"`
+				} `json:"interfaces"`
+			} `json:"network"`
+		}{
+			ID:               DefaultXimeraServerID1,
+			OwnerID:          DefaultUserID,
+			HypervisorID:     DefaultHypervisorID,
+			Name:             DefaultXimeraServerName1,
+			Hostname:         "test-hostname",
+			UUID:             "test-uuid-123",
+			State:            "complete",
+			CommissionStatus: 1,
+			PublicIP:         DefaultXimeraServerIP1,
+			Created:          time.Now().Add(-24 * time.Hour).Format(time.RFC3339),
+			Updated:          time.Now().Format(time.RFC3339),
+		},
+	}
+
+	// Add network interface data
+	defaultServer.Data.Network.Interfaces = []struct {
+		IPv4 []struct {
+			Address string `json:"address"`
+		} `json:"ipv4"`
+	}{
+		{
+			IPv4: []struct {
+				Address string `json:"address"`
+			}{
+				{Address: DefaultXimeraServerIP1},
+			},
+		},
+	}
+
+	// Create server with tag
+	serverWithTag := &ximeraTypes.XimeraServerResponse{
+		Data: defaultServer.Data,
+	}
+	serverWithTag.Data.ID = DefaultXimeraServerID2
+	serverWithTag.Data.Name = TestTagName
+	serverWithTag.Data.PublicIP = DefaultXimeraServerIP2
+
+	// Create default server list
+	defaultServerList := &ximeraTypes.XimeraServersListResponse{
+		Data: []struct {
+			ID           int    `json:"id"`
+			OwnerID      int    `json:"ownerId"`
+			HypervisorID int    `json:"hypervisorId"`
+			Name         string `json:"name"`
+			Hostname     string `json:"hostname"`
+			UUID         string `json:"uuid"`
+			State        string `json:"state"`
+		}{
+			{
+				ID:           DefaultXimeraServerID1,
+				OwnerID:      DefaultUserID,
+				HypervisorID: DefaultHypervisorID,
+				Name:         DefaultXimeraServerName1,
+				Hostname:     "test-hostname",
+				UUID:         "test-uuid-123",
+				State:        "complete",
+			},
+			{
+				ID:           DefaultXimeraServerID2,
+				OwnerID:      DefaultUserID,
+				HypervisorID: DefaultHypervisorID,
+				Name:         DefaultXimeraServerName2,
+				Hostname:     "test-hostname-2",
+				UUID:         "test-uuid-456",
+				State:        "complete",
+			},
+		},
+	}
+
+	// Create server list with tag
+	serverListWithTag := &ximeraTypes.XimeraServersListResponse{
+		Data: []struct {
+			ID           int    `json:"id"`
+			OwnerID      int    `json:"ownerId"`
+			HypervisorID int    `json:"hypervisorId"`
+			Name         string `json:"name"`
+			Hostname     string `json:"hostname"`
+			UUID         string `json:"uuid"`
+			State        string `json:"state"`
+		}{
+			{
+				ID:           DefaultXimeraServerID1,
+				OwnerID:      DefaultUserID,
+				HypervisorID: DefaultHypervisorID,
+				Name:         DefaultXimeraServerName1,
+				Hostname:     "test-hostname",
+				UUID:         "test-uuid-123",
+				State:        "complete",
+			},
+			{
+				ID:           DefaultXimeraServerID2,
+				OwnerID:      DefaultUserID,
+				HypervisorID: DefaultHypervisorID,
+				Name:         TestTagName, // Server with the tag as name
+				Hostname:     "test-hostname-tag",
+				UUID:         "test-uuid-tag",
+				State:        "complete",
+			},
+		},
+	}
+
+	// Create empty server list
+	emptyServerList := &ximeraTypes.XimeraServersListResponse{
+		Data: []struct {
+			ID           int    `json:"id"`
+			OwnerID      int    `json:"ownerId"`
+			HypervisorID int    `json:"hypervisorId"`
+			Name         string `json:"name"`
+			Hostname     string `json:"hostname"`
+			UUID         string `json:"uuid"`
+			State        string `json:"state"`
+		}{},
+	}
+
+	return &XimeraServerResponses{
+		DefaultServer:     defaultServer,
+		DefaultServerList: defaultServerList,
+		EmptyServerList:   emptyServerList,
+		ServerWithTag:     serverWithTag,
+		ServerListWithTag: serverListWithTag,
+	}
+}
+
+// newXimeraTemplateResponses creates standard template responses
+func newXimeraTemplateResponses() *XimeraTemplateResponses {
+	defaultTemplates := &ximeraTypes.XimeraTemplatesResponse{
+		Data: []ximeraTypes.XimeraTemplateGroup{
+			{
+				ID:          1,
+				Name:        "Ubuntu",
+				Description: "Ubuntu Operating Systems",
+				Icon:        "ubuntu",
+				Templates: []ximeraTypes.XimeraTemplate{
+					{
+						ID:          DefaultTemplateID,
+						Name:        "Ubuntu",
+						Version:     "22.04",
+						Variant:     "Server",
+						Arch:        1,
+						Description: "Ubuntu 22.04 LTS Server",
+						Icon:        "ubuntu",
+						EOL:         false,
+						DeployType:  1,
+						VNC:         false,
+						Type:        "linux",
+					},
+				},
+			},
+		},
+	}
+
+	return &XimeraTemplateResponses{
+		DefaultTemplates: defaultTemplates,
+	}
+}
+
+// newXimeraErrorResponses creates standard error responses
+func newXimeraErrorResponses() *XimeraErrorResponses {
+	return &XimeraErrorResponses{
+		NotFoundError:       ErrXimeraServerNotFound,
+		AuthenticationError: ErrXimeraUnauthorized,
+		RateLimitError:      ErrXimeraRateLimit,
+		ServerCreationError: fmt.Errorf("failed to create server"),
+		NetworkError:        ErrXimeraNetwork,
+	}
+}
+
+// NewMockXimeraAPIClient creates a new mock Ximera API client
+func NewMockXimeraAPIClient() *MockXimeraAPIClient {
+	client := &MockXimeraAPIClient{
+		StandardResponses: NewXimeraStandardResponses(),
+		nextID:            100000,
+	}
+
+	client.setupStandardResponses()
+	return client
+}
+
+// setupStandardResponses configures the mock client with standard successful responses
+func (c *MockXimeraAPIClient) setupStandardResponses() {
+	c.ListServersFunc = func() (*ximeraTypes.XimeraServersListResponse, error) {
+		c.mutex.Lock()
+		c.attemptCount++
+		c.mutex.Unlock()
+		return c.StandardResponses.Servers.DefaultServerList, nil
+	}
+
+	c.CreateServerFunc = func(name string, packageID int, storage, traffic, memory, cpuCores int) (*ximeraTypes.XimeraServerResponse, error) {
+		c.mutex.Lock()
+		c.attemptCount++
+		server := *c.StandardResponses.Servers.DefaultServer
+		server.Data.ID = c.nextID
+		c.nextID++
+		c.mutex.Unlock()
+		server.Data.Name = name
+		return &server, nil
+	}
+
+	c.GetServerFunc = func(id int) (*ximeraTypes.XimeraServerResponse, error) {
+		c.mutex.Lock()
+		c.attemptCount++
+		c.mutex.Unlock()
+		if id == DefaultXimeraServerID2 {
+			return c.StandardResponses.Servers.ServerWithTag, nil
+		}
+		if id == 3 {
+			// Handle custom test server for exact match test
+			customServer := &ximeraTypes.XimeraServerResponse{
+				Data: c.StandardResponses.Servers.DefaultServer.Data,
+			}
+			customServer.Data.ID = 3
+			customServer.Data.Name = TestTagName
+			customServer.Data.PublicIP = DefaultXimeraServerIP2
+			return customServer, nil
+		}
+		return c.StandardResponses.Servers.DefaultServer, nil
+	}
+
+	c.BuildServerFunc = func(id int, osID, name, sshKey string) (*ximeraTypes.XimeraServerResponse, error) {
+		c.mutex.Lock()
+		c.attemptCount++
+		c.mutex.Unlock()
+		server := *c.StandardResponses.Servers.DefaultServer
+		server.Data.ID = id
+		server.Data.Name = name
+		return &server, nil
+	}
+
+	c.DeleteServerFunc = func(id int) error {
+		c.mutex.Lock()
+		c.attemptCount++
+		c.mutex.Unlock()
+		return nil
+	}
+
+	c.ServerExistsFunc = func(name string) (bool, int, error) {
+		c.mutex.Lock()
+		c.attemptCount++
+		c.mutex.Unlock()
+		if name == TestTagName {
+			return true, DefaultXimeraServerID2, nil
+		}
+		return false, 0, nil
+	}
+
+	c.ListTemplatesFunc = func(packageID int) (*ximeraTypes.XimeraTemplatesResponse, error) {
+		c.mutex.Lock()
+		c.attemptCount++
+		c.mutex.Unlock()
+		return c.StandardResponses.Templates.DefaultTemplates, nil
+	}
+
+	c.WaitForServerCreationFunc = func(serverID int, timeoutSeconds int) error {
+		c.mutex.Lock()
+		c.attemptCount++
+		c.mutex.Unlock()
+		return nil
+	}
+}
+
+// ResetToStandard resets all mock functions to their standard responses
+func (c *MockXimeraAPIClient) ResetToStandard() {
+	c.setupStandardResponses()
+	c.mutex.Lock()
+	c.attemptCount = 0
+	c.mutex.Unlock()
+}
+
+// Mock API method implementations
+func (c *MockXimeraAPIClient) ListServers() (*ximeraTypes.XimeraServersListResponse, error) {
+	return c.ListServersFunc()
+}
+
+func (c *MockXimeraAPIClient) CreateServer(name string, packageID int, storage, traffic, memory, cpuCores int) (*ximeraTypes.XimeraServerResponse, error) {
+	return c.CreateServerFunc(name, packageID, storage, traffic, memory, cpuCores)
+}
+
+func (c *MockXimeraAPIClient) GetServer(id int) (*ximeraTypes.XimeraServerResponse, error) {
+	return c.GetServerFunc(id)
+}
+
+func (c *MockXimeraAPIClient) BuildServer(id int, osID, name, sshKey string) (*ximeraTypes.XimeraServerResponse, error) {
+	return c.BuildServerFunc(id, osID, name, sshKey)
+}
+
+func (c *MockXimeraAPIClient) DeleteServer(id int) error {
+	return c.DeleteServerFunc(id)
+}
+
+func (c *MockXimeraAPIClient) ServerExists(name string) (bool, int, error) {
+	return c.ServerExistsFunc(name)
+}
+
+func (c *MockXimeraAPIClient) ListTemplates(packageID int) (*ximeraTypes.XimeraTemplatesResponse, error) {
+	return c.ListTemplatesFunc(packageID)
+}
+
+func (c *MockXimeraAPIClient) WaitForServerCreation(serverID int, timeoutSeconds int) error {
+	return c.WaitForServerCreationFunc(serverID, timeoutSeconds)
+}
+
+// GetPackageID returns the default package ID for testing
+func (c *MockXimeraAPIClient) GetPackageID() int {
+	return DefaultPackageID
+}
+
+// Simulation methods for testing different scenarios
+
+// SimulateNotFound configures the client to return not found errors
+func (c *MockXimeraAPIClient) SimulateNotFound() {
+	c.ListServersFunc = func() (*ximeraTypes.XimeraServersListResponse, error) {
+		c.mutex.Lock()
+		c.attemptCount++
+		c.mutex.Unlock()
+		return nil, c.StandardResponses.Errors.NotFoundError
+	}
+	c.GetServerFunc = func(id int) (*ximeraTypes.XimeraServerResponse, error) {
+		c.mutex.Lock()
+		c.attemptCount++
+		c.mutex.Unlock()
+		return nil, c.StandardResponses.Errors.NotFoundError
+	}
+	c.DeleteServerFunc = func(id int) error {
+		c.mutex.Lock()
+		c.attemptCount++
+		c.mutex.Unlock()
+		return c.StandardResponses.Errors.NotFoundError
+	}
+}
+
+// SimulateAuthenticationFailure configures the client to return authentication errors
+func (c *MockXimeraAPIClient) SimulateAuthenticationFailure() {
+	c.ListServersFunc = func() (*ximeraTypes.XimeraServersListResponse, error) {
+		c.mutex.Lock()
+		c.attemptCount++
+		c.mutex.Unlock()
+		return nil, c.StandardResponses.Errors.AuthenticationError
+	}
+	c.CreateServerFunc = func(name string, packageID int, storage, traffic, memory, cpuCores int) (*ximeraTypes.XimeraServerResponse, error) {
+		c.mutex.Lock()
+		c.attemptCount++
+		c.mutex.Unlock()
+		return nil, c.StandardResponses.Errors.AuthenticationError
+	}
+	c.GetServerFunc = func(id int) (*ximeraTypes.XimeraServerResponse, error) {
+		c.mutex.Lock()
+		c.attemptCount++
+		c.mutex.Unlock()
+		return nil, c.StandardResponses.Errors.AuthenticationError
+	}
+}
+
+// SimulateRateLimit configures the client to return rate limit errors
+func (c *MockXimeraAPIClient) SimulateRateLimit() {
+	c.ListServersFunc = func() (*ximeraTypes.XimeraServersListResponse, error) {
+		c.mutex.Lock()
+		c.attemptCount++
+		c.mutex.Unlock()
+		return nil, c.StandardResponses.Errors.RateLimitError
+	}
+	c.CreateServerFunc = func(name string, packageID int, storage, traffic, memory, cpuCores int) (*ximeraTypes.XimeraServerResponse, error) {
+		c.mutex.Lock()
+		c.attemptCount++
+		c.mutex.Unlock()
+		return nil, c.StandardResponses.Errors.RateLimitError
+	}
+}
+
+// SimulateServerCreationError configures the client to return server creation errors
+func (c *MockXimeraAPIClient) SimulateServerCreationError() {
+	c.CreateServerFunc = func(name string, packageID int, storage, traffic, memory, cpuCores int) (*ximeraTypes.XimeraServerResponse, error) {
+		c.mutex.Lock()
+		c.attemptCount++
+		c.mutex.Unlock()
+		return nil, c.StandardResponses.Errors.ServerCreationError
+	}
+	c.WaitForServerCreationFunc = func(serverID int, timeoutSeconds int) error {
+		c.mutex.Lock()
+		c.attemptCount++
+		c.mutex.Unlock()
+		return fmt.Errorf("timeout waiting for server creation")
+	}
+}
+
+// SimulateEmptyServerList configures the client to return empty server lists
+func (c *MockXimeraAPIClient) SimulateEmptyServerList() {
+	c.ListServersFunc = func() (*ximeraTypes.XimeraServersListResponse, error) {
+		c.mutex.Lock()
+		c.attemptCount++
+		c.mutex.Unlock()
+		return c.StandardResponses.Servers.EmptyServerList, nil
+	}
+}
+
+// SimulateServerListWithTag configures the client to return a server list containing the tag
+func (c *MockXimeraAPIClient) SimulateServerListWithTag() {
+	c.ListServersFunc = func() (*ximeraTypes.XimeraServersListResponse, error) {
+		c.mutex.Lock()
+		c.attemptCount++
+		c.mutex.Unlock()
+		return c.StandardResponses.Servers.ServerListWithTag, nil
+	}
+}
+
+// SimulateNetworkError configures the client to return network errors
+func (c *MockXimeraAPIClient) SimulateNetworkError() {
+	c.ListServersFunc = func() (*ximeraTypes.XimeraServersListResponse, error) {
+		c.mutex.Lock()
+		c.attemptCount++
+		c.mutex.Unlock()
+		return nil, c.StandardResponses.Errors.NetworkError
+	}
+}
+
+// GetAttemptCount returns the current attempt count
+func (c *MockXimeraAPIClient) GetAttemptCount() int {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	return c.attemptCount
+}
+
+// ResetAttemptCount resets the attempt counter
+func (c *MockXimeraAPIClient) ResetAttemptCount() {
+	c.mutex.Lock()
+	c.attemptCount = 0
+	c.mutex.Unlock()
+}

--- a/test/suite.go
+++ b/test/suite.go
@@ -46,6 +46,7 @@ type Suite struct {
 	UserRepo     *repos.UserRepository
 	ProjectRepo  *repos.ProjectRepository
 	TaskRepo     *repos.TaskRepository
+	SSHKeyRepo   *repos.SSHKeyRepository
 
 	// Mock providers
 	MockDOClient *mocks.MockDOClient
@@ -91,6 +92,7 @@ func (s *Suite) SetupSuite() {
 	s.UserRepo = repos.NewUserRepository(db)
 	s.ProjectRepo = repos.NewProjectRepository(db)
 	s.TaskRepo = repos.NewTaskRepository(db)
+	s.SSHKeyRepo = repos.NewSSHKeyRepository(db)
 
 	// Create mock clients
 	s.MockDOClient = mocks.NewMockDOClient()


### PR DESCRIPTION
Closes #336 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added ability to retrieve compute instances by tag for both DigitalOcean and Ximera providers.
  - Enhanced Ximera provider with caching for server listings, improving performance and efficiency.
  - Improved error handling and messaging for SSH key operations.

- **Bug Fixes**
  - Ensured instance IDs are consistently included in task payloads and models after instance creation.
  - Improved validation to prevent instance creation without required IDs.

- **Tests**
  - Expanded and improved test coverage for instance creation, deletion, caching, and tag-based retrieval.
  - Enhanced mock clients for DigitalOcean and Ximera to better simulate real-world scenarios.

- **Chores**
  - Reduced logging verbosity for worker operations to debug level.
  - Integrated SSH key repository into the test suite for more comprehensive testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->